### PR TITLE
Ignore RUSTSEC-2026-0009 until time pin floats

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,19 @@
 # dependency graph. Yanked crates are a warning (sometimes unavoidable
 # transitively) rather than an error.
 yanked = "warn"
-ignore = []
+ignore = [
+    # RUSTSEC-2026-0009 — `time` < 0.3.47 DoS via stack exhaustion in
+    # the RFC-2822 parser. We're pinned to `time = ">=0.3, <0.3.46"`
+    # to avoid 0.3.46's stricter `year >= -9999` assertion that our
+    # `arb_offset_dt` proptest strategy trips on at the Date::MIN
+    # boundary with a non-zero UTC offset. Connections does not call
+    # any RFC-2822 parser path (no `parse(Rfc2822)`, no
+    # `OffsetDateTime::parse(_, &Rfc2822)`), so the attack surface
+    # is zero for our usage. Drop this entry after clamping
+    # `arb_date()`'s year range so we can float `time = "0.3"` and
+    # adopt the fix that landed in 0.3.47.
+    "RUSTSEC-2026-0009",
+]
 
 [bans]
 # Multiple versions of the same crate usually indicate a dependency


### PR DESCRIPTION
## Summary

- Post-merge `deny` job fails on `main`: RUSTSEC-2026-0009 (DoS via stack exhaustion in `time`'s RFC-2822 parser, fixed in 0.3.47). Our `time = ">=0.3, <0.3.46"` pin (set in PR #1 to avoid 0.3.46's stricter `year >= -9999` proptest panic) keeps us at 0.3.45 which is affected.
- Connections does not call any RFC-2822 parser path (no `parse(Rfc2822)`, no `OffsetDateTime::parse(_, &Rfc2822)`), so the attack surface is zero for our usage. Add `RUSTSEC-2026-0009` to `[advisories].ignore` with an inline comment tracking the followup.

## Verification

- `deny` job on `main` should pass after merge.
- All other jobs unchanged (1-line config edit, no source changes).

## Deferred (followup)

- Clamp `arb_date()`'s year range so any `UtcOffset` adjustment stays inside `[-9999, 9999]`, drop the `time = "<0.3.46"` pin, drop the `RUSTSEC-2026-0009` ignore. The original failing input from PR #1's investigation was `x = -9999-01-01 0:00:00.0 -06:30:01` — a 1-day cushion at each year boundary (so `[-9998, 9998]` instead of `[-9999, 9999]`) should resolve it.
- Address the GitHub-iid vs. historical-review-file collision (review-00002.md.. review-00098.md are GitLab MR audit trail; new GitHub PRs collide until we either renumber or jump the GitHub iid sequence past 98). Tracked separately.