### PR TITLE
fix(ci): Force nightly toolchain in doc-nightly workflow

### DIFF
--- a/.github/workflows/doc-nightly.yml
+++ b/.github/workflows/doc-nightly.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --no-deps --all-features --document-private-items
+      - run: cargo +nightly doc --no-deps --all-features --document-private-items

--- a/doc/reviews/review-00004.md
+++ b/doc/reviews/review-00004.md
@@ -1,0 +1,15 @@
+# PR #4 — fix(ci): Force nightly toolchain in doc-nightly workflow
+
+<!-- gh-id: 4285611139 -->
+### copilot-pull-request-reviewer[bot] — COMMENTED ([2026-05-13 21:48 UTC](https://github.com/cmk/connections/pull/4#pullrequestreview-4285611139))
+
+## Pull request overview
+
+Fixes the `doc-all-features-nightly` workflow which was failing because `rust-toolchain.toml` (channel "1.88") overrode the nightly toolchain installed by `dtolnay/rust-toolchain@nightly`. Using the `+nightly` shortcut takes precedence over `rust-toolchain.toml`, ensuring the doc build runs on nightly as intended.
+
+**Changes:**
+- Add `+nightly` shortcut to the `cargo doc` invocation in the doc-nightly workflow.
+
+
+
+


### PR DESCRIPTION
## Summary

The `doc-all-features-nightly` scheduled job has been red because `dtolnay/rust-toolchain@nightly` installs nightly but `rust-toolchain.toml` (channel = "1.88") wins over the `RUSTUP_TOOLCHAIN` env var the action sets. Result: the job actually ran on stable and tripped E0554 on `src/lib.rs:186`:

```
error[E0554]: `#![feature]` may not be used on the stable release channel
  --> src/lib.rs:186:30
```

Switching to `cargo +nightly doc …` uses the `+toolchain` shortcut, which sits one rung above `rust-toolchain.toml` in rustup's precedence list, so nightly wins.

Run that surfaced this: https://github.com/cmk/connections/actions/runs/25780080373

## Test plan

- [ ] CI green on this branch (the `+nightly` shortcut should resolve to the toolchain installed by `dtolnay/rust-toolchain@nightly`)
- [ ] After merge, the next scheduled `doc-all-features-nightly` run is green (or trigger via `workflow_dispatch` to confirm sooner)