### PR TITLE
ci(docs): Prune stale github-pages Deployment records after publish

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  deployments: write
 
 concurrency:
   group: 'pages'
@@ -42,3 +43,25 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+      - name: Prune previous github-pages deployments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # Best-effort cleanup. The artifact has already published by
+          # this point; any failure here (list, parse, or per-id
+          # mutation) is logged and ignored so a transient gh/jq error
+          # doesn't redden the deploy job. Stragglers get caught on the
+          # next push.
+          ids=$(
+            gh api "repos/$GH_REPO/deployments?environment=github-pages&per_page=100" \
+              | jq -r 'sort_by(.created_at) | reverse | .[1:] | .[].id'
+          ) || { echo "warn: could not list deployments to prune"; ids=; }
+          printf '%s\n' "$ids" | while read -r id; do
+            [ -n "$id" ] || continue
+            gh api --silent -X POST "repos/$GH_REPO/deployments/$id/statuses" \
+              -f state=inactive \
+              || echo "warn: could not mark $id inactive"
+            gh api --silent -X DELETE "repos/$GH_REPO/deployments/$id" \
+              || echo "warn: could not delete $id"
+          done

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,9 +53,17 @@ jobs:
           # mutation) is logged and ignored so a transient gh/jq error
           # doesn't redden the deploy job. Stragglers get caught on the
           # next push.
+          #
+          # `pipefail` makes a failing `gh api` propagate through the
+          # pipe so the `|| { warn }` fallback actually fires;
+          # otherwise jq exits 0 on empty input and we'd silently
+          # prune nothing.
+          # `--paginate` + `jq -s 'add // []'` covers >100 records, so
+          # a long-disabled workflow can still drain its backlog.
+          set -o pipefail
           ids=$(
-            gh api "repos/$GH_REPO/deployments?environment=github-pages&per_page=100" \
-              | jq -r 'sort_by(.created_at) | reverse | .[1:] | .[].id'
+            gh api --paginate "repos/$GH_REPO/deployments?environment=github-pages&per_page=100" \
+              | jq -s -r 'add // [] | sort_by(.created_at) | reverse | .[1:] | .[].id'
           ) || { echo "warn: could not list deployments to prune"; ids=; }
           printf '%s\n' "$ids" | while read -r id; do
             [ -n "$id" ] || continue


### PR DESCRIPTION
## Summary

Ports sprag PR #30 (`cmk/sprag#30`) to this repo's `pages.yml`. The Pages docs publish step (`actions/deploy-pages@v4` with `environment: github-pages`) creates a Deployment object on every push to main. Nothing pruned them, so the repo carries 4 records, all from this one environment.

## What changed

One post-deploy step inside the existing `deploy` job, right after `actions/deploy-pages@v4`. Marks every github-pages deployment except the newest `inactive`, then DELETEs it. `deployments: write` joins the workflow-level `permissions:` block so the job-scoped `GITHUB_TOKEN` can mutate the records.

The list step is wrapped in a fall-through so a transient `gh`/`jq` error doesn't redden the deploy job after the artifact already published. Per-id `inactive`/DELETE failures are logged but non-fatal. Stragglers get caught on the next run.

`.[1:]` keeps the newest record (the one `deploy-pages` just created) so the sidebar's active-deployment chip still resolves; everything older goes.

## Why it's safe to race

The workflow already declares `concurrency.group: 'pages'` with `cancel-in-progress: false`, so back-to-back main pushes queue rather than run in parallel. By the time the prune step in run N executes, run N+1 hasn't started yet.

## Test plan

- [ ] `GitHub Pages / build` and `GitHub Pages / deploy` jobs pass on this PR's own CI run.
- [ ] After merge: `gh api 'repos/cmk/connections/deployments?environment=github-pages' | jq length` drops from 4 to 1 once the Pages workflow runs on the merged commit.