### PR TITLE
LX sentinel, NonZero widening + narrowing, audit polish

### DIFF
--- a/doc/plans/plan-2026-05-19-02.md
+++ b/doc/plans/plan-2026-05-19-02.md
@@ -1,66 +1,83 @@
-# Plan 02 — KV-keyed signed ints, NonZero unsigned widening, audit polish
+# Plan 02 — LX-keyed signed ints, NonZero unsigned widening, audit polish
 
 ## Goal
 
-Three concerns rolled into one sprint:
+Four concerns rolled into one sprint:
 
-1. **KV sentinel** — new `KV<N>` byte-array wrapper with default
-   lex Ord, plus `IxxxKVxy` Conns from signed ints that produce a
-   bias-encoded big-endian representation directly orderable as a
-   key. Closes the only gap in the byte-encoding ladder where lex
-   compare disagrees with numeric compare; lets the crate produce
-   sort-correct keys for KV stores (LMDB / RocksDB / sled) that
-   compare bytes directly.
+1. **LX sentinel** — new `LX<N>` byte-array wrapper with default
+   lex `Ord` (raw lexicographic compare over the bytes), plus
+   `IxxxLXxy` bias-encoded big-endian Conns from signed ints
+   targeting it. Closes the only gap in the byte-encoding ladder
+   where lex compare disagreed with numeric compare; lets the crate
+   produce sort-correct keys for byte-keyed stores (LMDB / RocksDB /
+   sled) that compare bytes directly. The wrapper itself is
+   semantics-neutral — just "these bytes compare lex" — so other
+   downstream consumers can use it for arbitrary lex-ordered byte
+   data, not only the bias-encoded numeric case.
 2. **NonZero unsigned widening** — 10 new `N###N###` Conns
-   `NonZeroUN> → NonZeroUM` for every N < M pair across
+   `NonZeroUN → NonZeroUM` for every N < M pair across
    {8, 16, 32, 64, 128}. Mirrors the existing `U###U###` widening
    family at the NonZero layer.
-3. **Audit polish** — clean up the leftover items from the
+3. **NonZero narrowing (added mid-sprint)** — 20 new `N###N###`
+   Conns (10 signed + 10 unsigned narrowings) via two new macros
+   `nz_int_narrow!` and `nz_uint_narrow!`. Signed widening was
+   investigated and **permanently dropped**: it cannot be expressed
+   as a bare `Conn<NonZero<i_N>, NonZero<i_M>>` because the target
+   has a lower plateau with no `-Inf` representative in `NonZero<i_N>`
+   (no `Extended<NonZero<>>` infrastructure exists). See Deferred.
+4. **Audit polish** — clean up the leftover items from the
    four-agent code-health audit that didn't land in plan-01.
 
 ## Dependency Graph
 
-T1 (KV<N> wrapper) → T2 (IxxxKVxy Conns) → T3 (nz_uint_widen! macro)
-→ T4 (N###N### Conns) → T5..T11 (polish, all independent) → T12
-(build gate).
+T1 (LX<N> wrapper) → T2 (IxxxLXxy Conns) → T3 (nz_uint_widen! macro)
+→ T4 (N###N### Conns) → T5..T11 (polish, all independent) → T13
+(nz_int_narrow + nz_uint_narrow macros + 20 Conns) → T12 (build gate).
 
 T1+T2 share `src/core.rs` and the i8…i128 modules; T3+T4 share the
-u8…u128 modules. T5..T11 are independent of T1..T4 and each other.
+u8…u128 modules; T13 spans both i8…i128 (signed narrowing,
+source-side hosting) and u8…u128 (unsigned narrowing, source-side
+hosting). T5..T11 are independent of T1..T4 / T13 and each other.
 
 ## Tasks
 
-### T1 — `KV<N>` byte-array wrapper
+### T1 — `LX<N>` byte-array wrapper
 
 Problem: the existing byte-encoding family covers signed (`B2<N>` /
 `L2<N>` with custom Ord) and unsigned-LE (`LE<N>` with custom Ord),
-but has no wrapper for *bias-encoded* signed bytes whose default Ord
-agrees with numeric order. KV stores compare bytes directly without
-consulting Rust's `Ord` impl, so `B2`'s custom impl can't help
-there — the stored bytes themselves must be lex-orderable.
+but has no wrapper whose *default* `Ord` is raw byte lex. Byte-keyed
+stores compare bytes directly without consulting Rust's `Ord` impl,
+so `B2`'s custom impl can't help there — the stored bytes themselves
+must be lex-orderable.
 
 Solution: add a new wrapper in `src/core.rs`:
 
 ```rust
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct KV<const N: usize>(pub [u8; N]);
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct LX<const N: usize>(pub [u8; N]);
 ```
 
-Default-derived `Ord` is the raw byte lex compare — exactly what
-KV stores do internally. `From`/`AsRef` shims mirror `B2`/`L2`/`LE`.
-No custom Ord impl; documentation must spell out that the *encoder*
-(the Conn) does the work, not the wrapper.
+(`Default` intentionally not in the derive — `[u8; N]` only impls
+`Default` for `N ≤ 32` in const-generic-free form, and the sibling
+`B2`/`L2`/`LE` wrappers don't have it either.)
 
-KV is big-endian by construction (no `KV_LE` variant). Per the user
-note: ordered keys are big-endian by construction because lex compare
-walks byte 0 forward. Little-endian physical bytes are storage, not
-keys.
+Default-derived `Ord` is the raw byte lex compare — exactly what
+byte-keyed stores do internally. `From`/`AsRef` shims mirror
+`B2`/`L2`/`LE`. No custom Ord impl; documentation spells out that
+the wrapper is semantics-neutral (just "these bytes compare lex"),
+and any numeric-equivalence claim lives on the *encoder* Conn
+(`IxxxLXxy`), not on the wrapper.
+
+The bias-encoded Conn family that targets `LX<N>` is big-endian by
+construction: lex compare walks byte 0 forward, so little-endian
+physical bytes can't serve as lex keys for numeric data.
 
 Sentinel publishes at the crate root via the `core` namespace —
-`connections::core::KV` — alongside `B2` / `L2` / `LE`. No re-export
+`connections::core::LX` — alongside `B2` / `L2` / `LE`. No re-export
 at the crate root (per plan-01's no-bare-names rule).
 
-### T2 — `IxxxKVxy` Conns
+### T2 — `IxxxLXxy` Conns
 
 Problem: signed ints encoded as 2s-complement bytes don't lex-sort
 correctly (`i8::MIN = 0x80 > 0x7F = i8::MAX` in raw byte compare).
@@ -73,11 +90,11 @@ Solution: add five Conns hosted in `src/core/iNNN.rs`:
 
 | Conn        | Source | Target  | Encoding                                |
 |-------------|--------|---------|-----------------------------------------|
-| `I008KV01`  | `i8`   | `KV<1>` | `[(x as u8).wrapping_add(0x80)]`        |
-| `I016KV02`  | `i16`  | `KV<2>` | `(x as u16 + 0x8000).to_be_bytes()`     |
-| `I032KV04`  | `i32`  | `KV<4>` | `(x as u32 + 0x80000000).to_be_bytes()` |
-| `I064KV08`  | `i64`  | `KV<8>` | similar                                 |
-| `I128KV16`  | `i128` | `KV<16>`| similar                                 |
+| `I008LX01`  | `i8`   | `LX<1>` | `[(x as u8).wrapping_add(0x80)]`        |
+| `I016LX02`  | `i16`  | `LX<2>` | `(x as u16 + 0x8000).to_be_bytes()`     |
+| `I032LX04`  | `i32`  | `LX<4>` | `(x as u32 + 0x80000000).to_be_bytes()` |
+| `I064LX08`  | `i64`  | `LX<8>` | similar                                 |
+| `I128LX16`  | `i128` | `LX<16>`| similar                                 |
 
 Each is a degenerate iso (lossless bijection both ways), declared
 via the `iso!` macro. Hosting follows the existing precedent of
@@ -95,9 +112,9 @@ Problem: no existing macro covers `NonZeroUN → NonZeroUM` widening.
 Existing `nz_uint_ext!` only handles the same-width `uN ↔ NonZeroUN`
 adjoint.
 
-Solution: add `nz_uint_widen!(NAME, $NZN, $NZM)` in `src/core.rs`,
-generating a `pub const NAME: Conn<NonZeroUN, NonZeroUM, L>` —
-left-Galois single-sided, exactly the shape used by `uint_uint!` for
+Solution: add `nz_uint_widen!(NAME, $NZN, $UN, $NZM, $UM)` in
+`src/core.rs`, generating a `pub const NAME: Conn<NonZeroUN, NonZeroUM, L>`
+— left-Galois single-sided, exactly the shape used by `uint_uint!` for
 the bare-primitive U###U### family. No `Extended` wrap is needed:
 the saturation is one-sided (only at `NonZeroUM > NonZeroUN::MAX as
 UM`), and `NonZeroU_N ≥ 1` rules out the zero gap.
@@ -187,6 +204,40 @@ absence that blocks HashSet / HashMap usage. Bound: `A: Hash`.
   `conn::std::i8` / `conn::fixed::u008` (pre-rename module paths).
   Audit + rewrite to `core::iNNN` / `fixed::uNNN`.
 
+### T13 — `nz_int_narrow!` + `nz_uint_narrow!` macros (added mid-sprint)
+
+Problem: the NonZero ladder had a same-shape gap at the narrowing end.
+Sprint-1 user note (`doc/notes/note-2026-05-19-01.md`, NonZero Conns
+section) called out three missing macros — `nz_int_widen!`,
+`nz_int_narrow!`, `nz_uint_narrow!`. After investigation only the
+two narrowing macros are soundly expressible as bare
+`Conn<NonZero<i_N>, NonZero<i_M>>`; the signed-widening case is
+permanently dropped (see Deferred for rationale).
+
+Solution: two new macros next to `nz_uint_widen!` in `src/core.rs`:
+
+- `nz_int_narrow!(NAME, NZ_N, I_N, NZ_M, I_M)` — `Conn<NonZero<i_N>,
+  NonZero<i_M>>` with `bits(I_N) > bits(I_M)`. `ceil` saturates
+  source values to `i_M::MIN`/`i_M::MAX` (both nonzero, so no zero
+  gap reappears). `inner` lossless-widens with the FINE_MAX fixup
+  pattern from `int_int_narrow!` (no FINE_MIN by the same source-
+  side-plateau argument). Left-Galois single-sided.
+- `nz_uint_narrow!(NAME, NZ_N, U_N, NZ_M, U_M)` — `Conn<NonZero<u_N>,
+  NonZero<u_M>>` with `bits(U_N) > bits(U_M)`. `ceil` saturates above
+  `u_M::MAX`; no low-end branch (`NonZero<u_N> ≥ 1 > 0 = u_M::MIN`).
+  `inner` lossless-widens with FINE_MAX fixup. Left-Galois.
+
+20 Conns total (10 each):
+
+| Macro / placement                  | Conns                                                                                   |
+|------------------------------------|-----------------------------------------------------------------------------------------|
+| `nz_int_narrow!` / `core::iNNN`    | `N016N008`, `N032N008..16`, `N064N008..32`, `N128N008..64` (source-side hosting)        |
+| `nz_uint_narrow!` / `core::uNNN`   | `N016N008`, `N032N008..16`, `N064N008..32`, `N128N008..64` (source-side hosting)        |
+
+Per-source signed/unsigned name collision (e.g. `core::i016::N016N008`
+vs `core::u016::N016N008`) is resolved by qualified-import per
+CLAUDE.md's collision rule.
+
 ### T12 — Build gate
 
 `cargo build --all-features`, `cargo test --features
@@ -206,15 +257,18 @@ fixed,proptest,macros,time`). All clean.
 | `kv_boundary_iN`   | `tests/core/iNNN` | `MIN → [0x00,…]`, `0 → [0x80,0x00,…]`, `MAX → [0xFF,…]` for every N |
 | `nz_widen_galois_l_NM` | `tests/core/uNNN` | L-Galois law holds over the new `N###N###` Conn for every (N,M) pair: `ceil(a) ≤ b ⟺ a ≤ inner(b)` |
 | `nz_widen_round_trip_NM` | `tests/core/uNNN` | `inner(ceil(n)) == n` for every `n: NonZeroUN`; lossless widening means the round-trip is exact below `UN::MAX` |
-| `nz_widen_saturates_NM` | `tests/core/uNNN` | `inner(m) == NonZeroUN::MAX` whenever `m.get() > UN::MAX as UM`
+| `nz_widen_saturates_NM` | `tests/core/uNNN` | `inner(m) == NonZeroUN::MAX` whenever `m.get() > UN::MAX as UM` |
+| `nz_int_narrow_galois_l_NM` | `src/core/iNNN` | L-Galois holds for every signed `N###N###` narrowing pair (M < N), both endpoints in `{8,16,32,64,128}` |
+| `nz_uint_narrow_galois_l_NM` | `src/core/uNNN` | L-Galois holds for every unsigned `N###N###` narrowing pair (M < N), both endpoints in `{8,16,32,64,128}` |
 
 ### Spot checks
 
-- `format!("{:?}", I008KV01.ceil(-1_i8))` produces the expected byte
+- `format!("{:?}", I008LX01.ceil(-1_i8))` produces the expected byte
   array — quick read-through that the encoder is intelligible.
-- `BTreeSet<KV<2>>` round-trips a sorted `i16` slice through
-  `I016KV02` and recovers the original order on iteration —
-  end-to-end demonstration of the KV property.
+- `BTreeSet<LX<2>>` round-trips a sorted `i16` slice through
+  `I016LX02` and recovers the original order on iteration —
+  end-to-end demonstration of the bias-encoder contract (signed
+  numeric compare ⟺ raw lex compare on the encoded bytes).
 - `N008N016` composes with `U008I008` via `compose_k!` to give a
   worked example of the new family flowing into existing ladders.
 
@@ -229,16 +283,27 @@ fixed,proptest,macros,time`). All clean.
 
 ## Deferred
 
-- **Signed NonZero cross-width family** (`N008N016` in
-  `src/core/i008.rs` etc.). User scoped this sprint to unsigned
-  only; the signed family is a follow-up.
+- **Signed NonZero widening** (`nz_int_widen!`, `Conn<NonZero<i_N>,
+  NonZero<i_M>>` for N < M). **Permanently dropped, not deferred**:
+  cannot be expressed as a bare `Conn` because the target range
+  `[i_M::MIN, i_N::MIN as i_M − 1]` has no representative in
+  `NonZero<i_N>`. The supremum of an empty set requires a `-Inf`
+  sentinel; `NonZero<i_N>` provides none. Both L-Galois and R-Galois
+  fail (L on the lower plateau, R on the upper). Contrast
+  `nz_uint_widen!`, where the lower plateau is empty because
+  `u_N::MIN = 0 < 1 = NonZero<u_M>::MIN`. Workaround: compose
+  `i_N → Extended<i_N>` (`ext_int!`-style) with `i_M → NonZero<i_M>`
+  (`nz_int_ext!`-style) when needed. A `nz_int_widen!` macro could be
+  added if/when `Extended<NonZero<i_N>>` infrastructure lands — a
+  separate sprint with its own design pass on the Extended trait
+  bounds.
 - **NonZero cross-sign Conns** (e.g., `NonZeroU8 → NonZeroI8`) and
   **NonZero → primitive widening** (e.g., `NonZeroI8 → i16`). Both
   scoped out; downstream can compose existing Conns.
 - **Doctest coverage on macro-generated Conn consts** in `src/fixed/*.rs`
   and most `src/core/i*.rs` / `core/u*.rs`. Still its own sprint
   (the bulk of doctest-style work would happen there).
-- **`serde` feature** for `Extended`/`ExtendedFloat`/`Interval`/`KV`/`B2`/`L2`/`LE`.
+- **`serde` feature** for `Extended`/`ExtendedFloat`/`Interval`/`LX`/`B2`/`L2`/`LE`.
   Common ask; deferred to a future sprint with a clear serialization
   shape decision.
 - **Convert `__float_*_body!` helpers to `pub(crate) macro_rules!`** —
@@ -250,4 +315,91 @@ fixed,proptest,macros,time`). All clean.
 
 ## Review
 
-(populated at sprint-finalisation step 7)
+### Design deviations
+
+- Wrapper renamed `KV<N>` → `LX<N>` mid-PR after a downstream agent
+  asked for relaxed semantics. The original `KV` ("key-value")
+  framing baked in the bias-encoded numeric-ordering use case; the
+  relaxed `LX` ("lex") framing keeps just the lex-`Ord` contract on
+  the bytes, so other consumers can use the wrapper for arbitrary
+  lex-ordered byte data without inheriting the numeric-equivalence
+  claim. The bias-encoded Conn family kept its semantics; just the
+  Conn names moved from `IxxxKVxy` to `IxxxLXxy` to match the
+  wrapper.
+- `LX<N>` wrapper does not need a custom `Ord` impl — the whole
+  point is that default-derived lex `Ord` IS the contract. Spelled
+  this out in the wrapper's doc; downstream confusion would expect
+  LX to "do something" beyond storage.
+- Did not add `Default` to `LX<N>`'s derive (unlike planned). `[u8;
+  N]` only implements `Default` for `N ≤ 32` in const-generic-free
+  form, and `B2`/`L2`/`LE` don't have it either. Stayed consistent.
+- `nz_uint_widen!` takes the primitive bit-widths as extra macro
+  parameters (`$UN`, `$UM`) so the saturation cap can be expressed
+  with primitive `as` casts. The plan said `nz_uint_widen!(NAME,
+  $NZN, $NZM)` (3 args); shipped is 5 args to support the cast
+  path. Cosmetic; documented at the macro decl.
+
+### Scope expansion: kani path sweep
+
+User flagged 3 stale `crate::fixed::iNNN` references after Plan-26
+moved consts to `crate::core::iNNN`. The same drift existed across
+**five more kani harnesses** (`ext_int.rs`, `int_narrow.rs`,
+`uint_narrow.rs`, `uint_sat.rs`, `uint_widen.rs`) — all silent in
+`cargo build`/`cargo test` because `src/kani/` is
+`cfg(all(kani, feature = "fixed"))`-gated, but every one would have
+failed under `cargo kani`. Swept all five in this commit; preserved
+the legitimate `fixed::iNNN` imports in `iso_family.rs` and
+`fix_fix_*.rs` (Q-format Conns genuinely host there). Reorganised
+each harness's grouping from per-destination to per-source so the
+import path matches the actual hosting rule.
+
+### Drift caught (gardener rule)
+
+- `src/lib.rs:13` — `F016` row cited `core::f016::F016`; the type
+  actually lives in `crate::float::F016`. Repointed.
+- `src/fixed.rs:60-78` — stale migration prose left over from the
+  Plan-26 split. Removed.
+- `tests/core/*.rs` and `tests/fixed/*.rs` header docs all said
+  `conn::std::iN` / `conn::fixed::uN` (pre-rename module paths).
+  Bulk rewrite to `core::iNNN` / `fixed::uNNN`.
+- 17+ GitLab `MR !63…!69 round-N` parenthetical citations in
+  `src/hifi/{calendar,epoch,duration}.rs` — frozen archive refs with
+  no GitHub equivalent. Removed (per plan); two read more naturally
+  rephrased rather than deleted.
+
+### Deferred follow-ups (out of scope here)
+
+- LX proptest battery on `I016`/`I032`/`I064`/`I128`. Added the
+  battery for `I008LX01`; the wider Conns share the same iso shape
+  and inherit correctness from the macro, but full-width batteries
+  would be a follow-up if symmetry is desired.
+- **Signed NonZero widening (`nz_int_widen!`) — permanently dropped,
+  not deferred.** See Deferred section above for the Galois-law
+  soundness argument. Compositional workaround via `nz_int_ext!` +
+  `ext_int!` available today.
+- `NonZero → primitive` widening, NonZero cross-sign Conns.
+  Compositional via existing Conns.
+- The big one: doctest coverage on macro-generated Conn consts in
+  `src/fixed/*.rs` and most `src/core/iNNN.rs` / `uNNN.rs`. Still
+  its own sprint.
+- `serde` feature for `Extended` / `ExtendedFloat` / `Interval` /
+  `B2` / `L2` / `LE` / `LX`. The LX wrapper makes serde more useful
+  (storing typed keys); revisit alongside the other wrappers.
+
+### Recommendations
+
+- Before publish, expose `LX` alongside `B2`/`L2`/`LE` in any
+  curated examples doc — the four-wrapper family is now coherent and
+  the use cases (in-memory sort vs on-disk lex key) deserve a side-
+  by-side worked example.
+- The `nz_uint_widen!` template **does not** generalize to
+  `nz_int_widen!` despite the surface similarity — confirmed
+  mid-sprint by proptest. The unsigned case works because
+  `NonZero<u_M>` cannot represent values below `u_N::MIN = 0`, so
+  the would-be lower plateau is empty; the signed case has a
+  non-empty lower plateau (`[i_M::MIN, i_N::MIN as i_M − 1]`) that
+  no choice of `inner` can serve while preserving Galois law on the
+  source side. The "saturation logic shape is the same" intuition
+  was wrong; the relevant difference is whether the target type's
+  range extends below the source's minimum — which it does only on
+  the signed side.

--- a/doc/plans/plan-2026-05-19-02.md
+++ b/doc/plans/plan-2026-05-19-02.md
@@ -1,0 +1,253 @@
+# Plan 02 — KV-keyed signed ints, NonZero unsigned widening, audit polish
+
+## Goal
+
+Three concerns rolled into one sprint:
+
+1. **KV sentinel** — new `KV<N>` byte-array wrapper with default
+   lex Ord, plus `IxxxKVxy` Conns from signed ints that produce a
+   bias-encoded big-endian representation directly orderable as a
+   key. Closes the only gap in the byte-encoding ladder where lex
+   compare disagrees with numeric compare; lets the crate produce
+   sort-correct keys for KV stores (LMDB / RocksDB / sled) that
+   compare bytes directly.
+2. **NonZero unsigned widening** — 10 new `N###N###` Conns
+   `NonZeroUN> → NonZeroUM` for every N < M pair across
+   {8, 16, 32, 64, 128}. Mirrors the existing `U###U###` widening
+   family at the NonZero layer.
+3. **Audit polish** — clean up the leftover items from the
+   four-agent code-health audit that didn't land in plan-01.
+
+## Dependency Graph
+
+T1 (KV<N> wrapper) → T2 (IxxxKVxy Conns) → T3 (nz_uint_widen! macro)
+→ T4 (N###N### Conns) → T5..T11 (polish, all independent) → T12
+(build gate).
+
+T1+T2 share `src/core.rs` and the i8…i128 modules; T3+T4 share the
+u8…u128 modules. T5..T11 are independent of T1..T4 and each other.
+
+## Tasks
+
+### T1 — `KV<N>` byte-array wrapper
+
+Problem: the existing byte-encoding family covers signed (`B2<N>` /
+`L2<N>` with custom Ord) and unsigned-LE (`LE<N>` with custom Ord),
+but has no wrapper for *bias-encoded* signed bytes whose default Ord
+agrees with numeric order. KV stores compare bytes directly without
+consulting Rust's `Ord` impl, so `B2`'s custom impl can't help
+there — the stored bytes themselves must be lex-orderable.
+
+Solution: add a new wrapper in `src/core.rs`:
+
+```rust
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct KV<const N: usize>(pub [u8; N]);
+```
+
+Default-derived `Ord` is the raw byte lex compare — exactly what
+KV stores do internally. `From`/`AsRef` shims mirror `B2`/`L2`/`LE`.
+No custom Ord impl; documentation must spell out that the *encoder*
+(the Conn) does the work, not the wrapper.
+
+KV is big-endian by construction (no `KV_LE` variant). Per the user
+note: ordered keys are big-endian by construction because lex compare
+walks byte 0 forward. Little-endian physical bytes are storage, not
+keys.
+
+Sentinel publishes at the crate root via the `core` namespace —
+`connections::core::KV` — alongside `B2` / `L2` / `LE`. No re-export
+at the crate root (per plan-01's no-bare-names rule).
+
+### T2 — `IxxxKVxy` Conns
+
+Problem: signed ints encoded as 2s-complement bytes don't lex-sort
+correctly (`i8::MIN = 0x80 > 0x7F = i8::MAX` in raw byte compare).
+Bias by `1 << (bits-1)` flips this: every `iN` value `x` maps to
+`(x as wN).wrapping_add(MIN_BIAS)` where `wN` is the same-width
+unsigned; the result has the property that lex compare on the
+big-endian bytes matches signed numeric compare on `x`.
+
+Solution: add five Conns hosted in `src/core/iNNN.rs`:
+
+| Conn        | Source | Target  | Encoding                                |
+|-------------|--------|---------|-----------------------------------------|
+| `I008KV01`  | `i8`   | `KV<1>` | `[(x as u8).wrapping_add(0x80)]`        |
+| `I016KV02`  | `i16`  | `KV<2>` | `(x as u16 + 0x8000).to_be_bytes()`     |
+| `I032KV04`  | `i32`  | `KV<4>` | `(x as u32 + 0x80000000).to_be_bytes()` |
+| `I064KV08`  | `i64`  | `KV<8>` | similar                                 |
+| `I128KV16`  | `i128` | `KV<16>`| similar                                 |
+
+Each is a degenerate iso (lossless bijection both ways), declared
+via the `iso!` macro. Hosting follows the existing precedent of
+byte-encoding Conns living in the source-side module (cf.
+`I008BE01` at `src/core/i008.rs:56`).
+
+Verification properties (per Conn): `round_trip` (`upper(ceil(x)) == x`
+for every `x: iN`), `monotone_be` (`x < y` ⟺ raw lex compare on
+`ceil(x).0 < ceil(y).0`), `boundary_bytes` (`MIN → [0x00, …]`,
+`0 → [0x80, 0x00, …]`, `MAX → [0xFF, …]`).
+
+### T3 — `nz_uint_widen!` macro
+
+Problem: no existing macro covers `NonZeroUN → NonZeroUM` widening.
+Existing `nz_uint_ext!` only handles the same-width `uN ↔ NonZeroUN`
+adjoint.
+
+Solution: add `nz_uint_widen!(NAME, $NZN, $NZM)` in `src/core.rs`,
+generating a `pub const NAME: Conn<NonZeroUN, NonZeroUM, L>` —
+left-Galois single-sided, exactly the shape used by `uint_uint!` for
+the bare-primitive U###U### family. No `Extended` wrap is needed:
+the saturation is one-sided (only at `NonZeroUM > NonZeroUN::MAX as
+UM`), and `NonZeroU_N ≥ 1` rules out the zero gap.
+
+- `ceil`: lossless widen — `NonZeroUM::new(n.get() as UM).unwrap()`.
+  Always succeeds because `NonZeroUN::get() ≥ 1`.
+- `inner`: saturate at `NonZeroUN::MAX`. Maps `NonZeroUM` values
+  with `.get() > UN::MAX as UM` to `NonZeroUN::MAX`; others to
+  `NonZeroUN::new(m.get() as UN).unwrap()`.
+
+Export under `connections::macros::nz_uint_widen!` (add to the macros
+table in `src/lib.rs:283-302`).
+
+### T4 — 10 NonZero cross-width Conns
+
+For every pair `(N, M)` with `N < M` in `{8, 16, 32, 64, 128}`:
+
+| Conn        | Source                       | Target          | Host file              |
+|-------------|------------------------------|-----------------|------------------------|
+| `N008N016`  | `NonZeroU8`         | `NonZeroU16`    | `src/core/u008.rs`     |
+| `N008N032`  | `NonZeroU8`         | `NonZeroU32`    | `src/core/u008.rs`     |
+| `N008N064`  | `NonZeroU8`         | `NonZeroU64`    | `src/core/u008.rs`     |
+| `N008N128`  | `NonZeroU8`         | `NonZeroU128`   | `src/core/u008.rs`     |
+| `N016N032`  | `NonZeroU16`        | `NonZeroU32`    | `src/core/u016.rs`     |
+| `N016N064`  | `NonZeroU16`        | `NonZeroU64`    | `src/core/u016.rs`     |
+| `N016N128`  | `NonZeroU16`        | `NonZeroU128`   | `src/core/u016.rs`     |
+| `N032N064`  | `NonZeroU32`        | `NonZeroU64`    | `src/core/u032.rs`     |
+| `N032N128`  | `NonZeroU32`        | `NonZeroU128`   | `src/core/u032.rs`     |
+| `N064N128`  | `NonZeroU64`        | `NonZeroU128`   | `src/core/u064.rs`     |
+
+The signed cross-width `N###N###` family is intentionally deferred
+(not in scope this sprint).
+
+### T5 — Doctest-style violations
+
+Fix `assert!(x <= y)` / `assert!(x >= y)` / `assert!(lo <= x && x <= hi)`
+patterns in:
+
+- `src/core/f032.rs:56-57`
+- `src/core/f064.rs:70,113`
+- `src/core/bool.rs:105`
+
+Per memory `feedback_doctest_style`: replace with `assert_eq!` against
+concrete values bound to meaningful names. The `lo_back && hi_back`
+patterns are tautological for a well-typed `ceil`/`floor` and add no
+test value.
+
+### T6 — `f16` docsrs gating
+
+Add `#[cfg_attr(docsrs, doc(cfg(feature = "f16")))]` mirrors to the
+`f16`-gated items in `src/core/f032.rs` (lines 11, 13, 17, 26, 35, 44
+per audit) and `src/core/f064.rs` (lines 11, 32, 41, 50, 59). Keeps
+the docs.rs-rendered output consistent with the `fixed` / `time`
+feature breadcrumbs already applied at the module level.
+
+### T7 — GitLab MR artifact sweep
+
+Replace 17 references to `MR !63…!69` (round-N) in
+`src/hifi/{calendar,epoch,duration}.rs`. Either delete the
+parenthetical citation entirely (most read fine without it) or
+rewrite as `(reviewed)`. Do NOT renumber to GitHub PR ids — the
+old IDs have no GitHub equivalent.
+
+### T8 — `law_battery!` doc row
+
+Add a row for `law_battery!` to the macros table at
+`src/lib.rs:283-302`, alongside `lift_l!` / `lift_r!` / `lift_k!`
+added in plan-01. Source link: `crate::law_battery`.
+
+### T9 — Stale fixed.rs migration comment
+
+Strip lines 60-78 of the "for backward-compat … during the
+migration" paragraph at `src/fixed.rs`. The migration is done; line 78
+already says so. Keep the rest of the module doc.
+
+### T10 — `Interval<A>` Hash derive
+
+Add `Hash` to the `#[derive(...)]` pack on `Interval<A>` at
+`src/interval.rs:68`. Already has `Eq` but not `Hash` — surprising
+absence that blocks HashSet / HashMap usage. Bound: `A: Hash`.
+
+### T11 — Drift cleanups
+
+- `src/lib.rs:13` — `F016` row points at `core::f016::F016` but the
+  type lives in `crate::float`. Repoint the path.
+- `tests/core/*.rs` and `tests/fixed/*.rs` headers still reference
+  `conn::std::i8` / `conn::fixed::u008` (pre-rename module paths).
+  Audit + rewrite to `core::iNNN` / `fixed::uNNN`.
+
+### T12 — Build gate
+
+`cargo build --all-features`, `cargo test --features
+fixed,time,hifi,macros,proptest`, `cargo clippy --all-targets --
+-D warnings`, and the docsrs simulation (`RUSTDOCFLAGS="--cfg docsrs
+-D warnings" cargo +nightly doc --no-deps --features
+fixed,proptest,macros,time`). All clean.
+
+## Verification
+
+### Properties (must pass)
+
+| Property | Module | Invariant |
+|----------|--------|-----------|
+| `kv_round_trip_iN` | `tests/core/iNNN` | `upper(ceil(x)) == x` over every `x: iN` for every N ∈ {8,16,32,64,128} |
+| `kv_monotone_iN`   | `tests/core/iNNN` | `x < y` ⟺ `ceil(x).0 < ceil(y).0` under raw byte lex, every N |
+| `kv_boundary_iN`   | `tests/core/iNNN` | `MIN → [0x00,…]`, `0 → [0x80,0x00,…]`, `MAX → [0xFF,…]` for every N |
+| `nz_widen_galois_l_NM` | `tests/core/uNNN` | L-Galois law holds over the new `N###N###` Conn for every (N,M) pair: `ceil(a) ≤ b ⟺ a ≤ inner(b)` |
+| `nz_widen_round_trip_NM` | `tests/core/uNNN` | `inner(ceil(n)) == n` for every `n: NonZeroUN`; lossless widening means the round-trip is exact below `UN::MAX` |
+| `nz_widen_saturates_NM` | `tests/core/uNNN` | `inner(m) == NonZeroUN::MAX` whenever `m.get() > UN::MAX as UM`
+
+### Spot checks
+
+- `format!("{:?}", I008KV01.ceil(-1_i8))` produces the expected byte
+  array — quick read-through that the encoder is intelligible.
+- `BTreeSet<KV<2>>` round-trips a sorted `i16` slice through
+  `I016KV02` and recovers the original order on iteration —
+  end-to-end demonstration of the KV property.
+- `N008N016` composes with `U008I008` via `compose_k!` to give a
+  worked example of the new family flowing into existing ladders.
+
+### Build gates
+
+- cargo build, test, clippy --all-targets — all clean across the
+  feature matrix `--features ""`, `--features fixed`, `--features
+  "fixed,time,hifi,macros,proptest"`.
+- `cargo doc --no-deps` under
+  `RUSTDOCFLAGS="--cfg docsrs -D warnings"` and `+nightly` succeeds.
+- New surface tests in `tests/core/surface.rs` pass.
+
+## Deferred
+
+- **Signed NonZero cross-width family** (`N008N016` in
+  `src/core/i008.rs` etc.). User scoped this sprint to unsigned
+  only; the signed family is a follow-up.
+- **NonZero cross-sign Conns** (e.g., `NonZeroU8 → NonZeroI8`) and
+  **NonZero → primitive widening** (e.g., `NonZeroI8 → i16`). Both
+  scoped out; downstream can compose existing Conns.
+- **Doctest coverage on macro-generated Conn consts** in `src/fixed/*.rs`
+  and most `src/core/i*.rs` / `core/u*.rs`. Still its own sprint
+  (the bulk of doctest-style work would happen there).
+- **`serde` feature** for `Extended`/`ExtendedFloat`/`Interval`/`KV`/`B2`/`L2`/`LE`.
+  Common ask; deferred to a future sprint with a clear serialization
+  shape decision.
+- **Convert `__float_*_body!` helpers to `pub(crate) macro_rules!`** —
+  the plan-01 round confirmed `#[macro_export]` is mandatory for
+  `$crate::` resolution; revisit only if a real isolation mechanism
+  emerges.
+- **Unpin `time <0.3.46`** — needs the proptest date generator clamp;
+  still a follow-up.
+
+## Review
+
+(populated at sprint-finalisation step 7)

--- a/doc/reviews/review-00007.md
+++ b/doc/reviews/review-00007.md
@@ -1,0 +1,492 @@
+# PR #7 — LX-keyed signed ints, NonZero widening + narrowing, audit polish
+
+## Summary
+
+Second pre-publish polish pass on the `connections` crate. Four
+concerns:
+
+1. **LX sentinel** — a new byte-array wrapper with default-derived
+   lex `Ord` (semantics-neutral on the bytes themselves), plus
+   bias-encoded big-endian `IxxxLXxy` Conns from signed ints
+   targeting it. Closes the only gap in the byte-encoding ladder
+   where lex compare disagreed with numeric compare; lets the crate
+   produce sort-correct keys for byte-keyed stores (LMDB / RocksDB /
+   sled) that compare bytes directly. *Renamed `KV` → `LX` late in
+   review*: see "Wrapper rename" below.
+2. **NonZero unsigned widening** — 10 new `N###N###` Conns
+   `NonZeroU<N> → NonZeroU<M>` for every `N < M` across {8,16,32,
+   64,128}. Mirrors the existing `U###U###` widening family at the
+   NonZero layer; closes the user-flagged gap.
+3. **NonZero narrowing (added mid-sprint)** — 20 new `N###N###`
+   Conns via two new macros `nz_int_narrow!` and `nz_uint_narrow!`
+   (10 each, one per N > M pair). The matching `nz_int_widen!` was
+   investigated and **permanently dropped** as unsound on the bare
+   `Conn` type — see "NonZero narrowing" section below.
+4. **Audit polish** — leftover items from the four-agent code-health
+   audit that didn't land in plan-01, plus a kani-tree path sweep
+   triggered by user-flagged drift after the Plan-26 `core/`/`fixed/`
+   split.
+
+### LX (T1-T2)
+
+- `connections::core::LX<const N: usize>(pub [u8; N])` — new
+  wrapper with default-derived `Ord` (raw lex on the bytes). No
+  custom `Ord` impl: the whole contract is that the bytes
+  compare lexicographically. The wrapper is semantics-neutral —
+  numeric-equivalence claims live on the bias-encoded Conn, not on
+  the wrapper, so downstream consumers can use `LX<N>` for arbitrary
+  lex-ordered byte data.
+- Five signed-int bias-encoder isos: `I008LX01`, `I016LX02`,
+  `I032LX04`, `I064LX08`, `I128LX16`, hosted source-side per the
+  existing byte-encoding precedent (`I008BE01` lives in
+  `src/core/i008.rs`). Each is `iso!`-declared (degenerate Galois
+  iso, full triple). Encoder biases by `1 << (bits-1)` then
+  big-endian; decoder unbiases. Property suite on `I008LX01` covers
+  iso-roundtrip / galois L+R / floor_le_ceil / order-preservation
+  (signed numeric compare ⟺ raw byte lex compare on the encoded
+  bytes — the contract the bias encoding earns).
+
+### Wrapper rename `KV` → `LX`
+
+Late in review, a downstream agent asked for the type's semantics
+relaxed from "key-value store key" to plain lexicographic byte
+ordering. The original `KV` ("key-value") framing baked in the
+bias-encoded numeric-ordering use case; the relaxed `LX` ("lex")
+framing keeps only the default-`Ord`-is-lex contract on the bytes,
+so other consumers can use the wrapper for arbitrary lex-ordered
+byte data without inheriting the numeric-equivalence claim.
+
+Mechanical impact: type `KV<N>` → `LX<N>`; helper fns
+`{i8,i16,i32,i64,i128}_to_kv{01,02,04,08,16}` and inverses →
+`*_to_lx*` / `lx*_to_*`; Conn constants `I###KV0N` → `I###LX0N`;
+test identifiers `i00Nkv0N_*` / `arb_kvbyteN` → `i00Nlx0N_*` /
+`arb_lxbyteN`. The bias-encoded Conn family kept its semantics
+unchanged; the rename only affects the wrapper-as-an-`Ord`-contract
+identity. Doc on the wrapper now spells out that it is semantics-
+neutral.
+
+### NonZero unsigned widening (T3-T4)
+
+- `nz_uint_widen!` macro added to `src/core.rs` next to
+  `nz_uint_ext!`. Generates `pub const NAME: Conn<NonZeroUN,
+  NonZeroUM, L>` — left-Galois single-sided, mirroring `uint_uint!`
+  at the NonZero layer. `ceil` lossless-widens (no zero gap because
+  `NonZeroU<N> ≥ 1`); `inner` saturates at `NonZeroU<N>::MAX`.
+- 10 Conns landed in `src/core/uNNN.rs` (source-side per CLAUDE.md
+  placement rule): `N008N016` … `N064N128`. Spot tests on
+  `N008N016` for boundary saturation behavior; galois-L proptest
+  battery on every (N,M) pair.
+- Macro added to `connections::macros` re-export under the
+  `macros` feature; docs table in `src/lib.rs` extended with rows
+  for `nz_uint_widen!` and `law_battery!`.
+
+### NonZero narrowing (added mid-sprint)
+
+User flagged three missing macros in `doc/notes/note-2026-05-19-01.md`
+(NonZero Conns section): `nz_int_widen!`, `nz_int_narrow!`,
+`nz_uint_narrow!`. After investigation, only the two narrowing
+macros are soundly expressible as bare `Conn<NonZero<i_N>,
+NonZero<i_M>>`.
+
+**`nz_int_narrow!`** — signed `NonZero<i_N> → NonZero<i_M>` with
+N > M, left-Galois. `ceil` saturates source values to `i_M::MIN` /
+`i_M::MAX` (both nonzero, so no zero gap reappears); `inner`
+lossless-widens with the FINE_MAX fixup pattern from
+`int_int_narrow!`. 10 Conns spanning every (N, M) pair with N > M:
+`N016N008`; `N032N{008,016}`; `N064N{008,016,032}`;
+`N128N{008,016,032,064}`. Source-side hosting in `src/core/iNNN.rs`.
+
+**`nz_uint_narrow!`** — unsigned `NonZero<u_N> → NonZero<u_M>` with
+N > M, left-Galois. `ceil` saturates above `u_M::MAX`; no low-end
+branch (`NonZero<u_N> ≥ 1 > 0 = u_M::MIN`). `inner` lossless-widens
+with FINE_MAX fixup. 10 Conns mirror the signed narrowing tier:
+`N016N008`; `N032N{008,016}`; `N064N{008,016,032}`;
+`N128N{008,016,032,064}`. Source-side hosting in `src/core/uNNN.rs`.
+
+Per-source signed/unsigned name collision (`core::i016::N016N008` vs
+`core::u016::N016N008`) is resolved by qualified-import per
+CLAUDE.md's collision rule.
+
+**Why `nz_int_widen!` was dropped.** Mirror the unsigned widening
+template at the signed layer:
+
+- `ceil`: lossless embedding `NZ<i_N> → NZ<i_M>` (N < M).
+- `inner`: saturate target values outside `[i_N::MIN, i_N::MAX]` to
+  the matching boundary.
+
+Implementing this and running the L-Galois proptest (with a=NZ(-128),
+b=NZ(-129)) gives: `ceil(a) = NZ(-128)`, LHS `NZ(-128) ≤ NZ(-129)` is
+**false**; `inner(b) = NZ(i_N::MIN) = NZ(-128)`, RHS `a ≤ inner(b)` is
+**true**. L-Galois violated. R-Galois fails symmetrically at the upper
+plateau. The root cause: the target range `[i_M::MIN, i_N::MIN as
+i_M − 1]` has no representative in `NonZero<i_N>` (the supremum of an
+empty set requires a `-Inf` sentinel that `NonZero<i_N>` doesn't
+provide). Contrast `nz_uint_widen!`, where the lower bound
+`u_N::MIN = 0 < 1 = NonZero<u_M>::MIN` makes that target range
+empty.
+
+Workaround for downstream users: compose `nz_int_ext!` +
+`ext_int!` to widen via `i_N → Extended<i_N> → i_M → NonZero<i_M>`.
+A future `nz_int_widen!` would need new `Extended<NonZero<i_N>>`
+infrastructure; out of scope here.
+
+### Stale-path sweep
+
+User flagged 3 stale `crate::fixed::iNNN` references in
+`src/kani/nz_ext.rs` + 2 hifi doc comments. The same drift existed
+across 5 more kani harnesses — sweep-fixed:
+
+- `src/kani/{ext_int,int_narrow,uint_narrow,uint_sat,uint_widen}.rs`:
+  all importing the moved consts via `crate::fixed::iNNN` /
+  `crate::fixed::uNNN`. Silent in `cargo build` / `cargo test`
+  because `src/kani/` is `cfg(all(kani, feature = "fixed"))`-gated;
+  would fail under `cargo kani`. Rewired to per-source-module paths
+  (`crate::core::iNNN` / `uNNN`).
+- Reorganised each harness's grouping from per-destination to
+  per-source so the import path matches the actual hosting after
+  the Plan-26 split.
+- Legitimate `fixed::iNNN` / `uNNN` imports preserved in
+  `iso_family.rs` and `fix_fix_*.rs` (Q-format Conns genuinely host
+  in `src/fixed/`).
+
+### Polish (T5-T11)
+
+- Doctest-style fixes in `src/core/f032.rs` and `src/core/f064.rs`:
+  replaced tautological `assert!(x <= y)` / `assert!(x >= y)`
+  bracketing with `assert_eq!` against named f16/f32 grid points
+  around PI. Aligns with memory `feedback_doctest_style`.
+- `#[cfg_attr(docsrs, doc(cfg(feature = "f16")))]` mirrors on
+  `F032F016` and `F064F016` — completes the docsrs feature-mirror
+  story.
+- 17+ GitLab `MR !63…!69 round-N` parentheticals removed from
+  `src/hifi/{calendar,epoch,duration}.rs` (frozen archive refs with
+  no GitHub equivalent).
+- `lib.rs` macros table extended with `nz_uint_widen!` and
+  `law_battery!` rows; both added to `connections::macros::*`
+  re-export.
+- Stale "for backward-compat during the migration" prose deleted
+  from `src/fixed.rs:60-78` (migration is done).
+- `src/lib.rs:13` F016 row repointed at `float::F016` (the actual
+  type location).
+- `src/interval.rs:68` — added `Hash` to `Interval<A>`'s derive
+  pack. Surprising absence given `Eq` was already there.
+- `tests/core/*.rs` and `tests/fixed/*.rs` headers swept of stale
+  `conn::std::iN` / `conn::fixed::uN` references (pre-rename module
+  paths).
+
+## Test plan
+
+- `cargo test --features fixed,time,hifi,macros,proptest` — 4922
+  passing (1827 lib +22 from LX/N###N### properties — adds 20 new
+  narrowing-pair galois props + 2 narrow-pair spot tests over the
+  previous round; 90 doctests +1 for I008LX01), 14 doctests ignored
+  per existing harness.
+- `cargo clippy --all-targets --features fixed,time,hifi,macros,
+  proptest -- -D warnings` — clean.
+- `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc
+  --no-deps --features fixed,proptest,macros,time` — clean.
+- Spot checks: `I008LX01` boundary table (MIN→0x00, 0→0x80,
+  MAX→0xFF), `N008N016` saturation at `u8::MAX`, `N016N008`
+  both-plateau saturation + FINE_MAX fixup.
+
+## Deferred
+
+See `doc/plans/plan-2026-05-19-02.md § Review`.
+
+## Local review (2026-05-19)
+
+**Branch:** plan/2026-05-19-02
+**Commits:** 5 (origin/main..plan/2026-05-19-02)
+**Reviewer:** Codex (`codex review --base origin/main`)
+**Prompt fingerprint:** AGENTS.md=b5f7584f2875c10abb637c9b483b4c7e0cb37891 calibration=missing
+
+---
+
+The code builds and tests pass in the checked feature sets, but the patch introduces a public documentation/API map entry pointing to a non-existent F016 path.
+
+Review comment:
+
+- [P3] Point F016 at the actual f16 module — src/lib.rs:13-13
+  With the `f16` feature enabled, `connections::float::F016` does not exist; the public alias is defined in `core::f016::F016`. Users following this naming table will be sent to a dead path unless this is reverted or a real `float::F016` re-export is added.
+
+
+<!-- gh-id: 3270931041 -->
+### Copilot on [`tests/fixed/u128.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931041) (2026-05-20 02:44 UTC)
+
+The doc comment references `tests/fixed/u08_galois.rs`, but that file doesn't exist in `tests/fixed/`. Please update the reference to an existing rationale location (e.g., `tests/fixed.rs`, or the relevant module file such as `tests/fixed/u008.rs`).
+
+<!-- gh-id: 3270931061 -->
+### Copilot on [`tests/fixed/u064.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931061) (2026-05-20 02:44 UTC)
+
+The doc comment references `tests/fixed/u08_galois.rs`, but that file doesn't exist in `tests/fixed/`. Please update the reference to an existing rationale location (e.g., `tests/fixed.rs`).
+
+<!-- gh-id: 3270931075 -->
+### Copilot on [`tests/fixed/u032.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931075) (2026-05-20 02:44 UTC)
+
+The doc comment references `tests/fixed/u08_galois.rs`, but that file doesn't exist in `tests/fixed/`. Please update the reference to an existing rationale location (e.g., `tests/fixed.rs`).
+
+<!-- gh-id: 3270931083 -->
+### Copilot on [`tests/fixed/u016.rs:4`](https://github.com/cmk/connections/pull/7#discussion_r3270931083) (2026-05-20 02:44 UTC)
+
+The doc comment references `tests/fixed/u08_galois.rs`, but that file doesn't exist in `tests/fixed/`. Please update the reference to an existing rationale location (e.g., `tests/fixed.rs`).
+
+<!-- gh-id: 3270931091 -->
+### Copilot on [`tests/fixed/u008.rs:9`](https://github.com/cmk/connections/pull/7#discussion_r3270931091) (2026-05-20 02:44 UTC)
+
+This comment refers to `tests/fixed/u<width>_galois.rs` as a standalone invocation, but the fixed batteries are currently aggregated under `tests/fixed.rs` (with per-module `#[path] mod ...`). Please update the filename reference (and the standalone-invocation claim, if applicable) so it matches the current test layout.
+
+<!-- gh-id: 3270931099 -->
+### Copilot on [`tests/core/u128.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931099) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale location (e.g., `tests/core.rs` and/or `tests/core/u008.rs`).
+
+<!-- gh-id: 3270931111 -->
+### Copilot on [`tests/core/u064.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931111) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale location (e.g., `tests/core.rs` and/or `tests/core/u008.rs`).
+
+<!-- gh-id: 3270931118 -->
+### Copilot on [`tests/core/u032.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931118) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale location (e.g., `tests/core.rs` and/or `tests/core/u008.rs`).
+
+<!-- gh-id: 3270931124 -->
+### Copilot on [`tests/core/u016.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931124) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale/counterexample location (e.g., `tests/core/u008.rs` or the crate-level aggregator `tests/core.rs`).
+
+<!-- gh-id: 3270931134 -->
+### Copilot on [`tests/core/u008.rs:5`](https://github.com/cmk/connections/pull/7#discussion_r3270931134) (2026-05-20 02:44 UTC)
+
+This doc comment references `tests/fixed/u<width>_galois.rs`, but that file pattern doesn't exist in the current tree. Please update the reference to match the current fixed test layout (e.g., `tests/fixed.rs` or `tests/fixed/u008.rs`).
+
+<!-- gh-id: 3270931151 -->
+### Copilot on [`tests/core/i128.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931151) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale location (e.g., `tests/core.rs` and/or `tests/core/u008.rs`).
+
+<!-- gh-id: 3270931161 -->
+### Copilot on [`tests/core/i064.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931161) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale/counterexample location (e.g., `tests/core/u008.rs` or `tests/core.rs`).
+
+<!-- gh-id: 3270931174 -->
+### Copilot on [`tests/core/i032.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931174) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale/counterexample location (e.g., `tests/core/u008.rs` or `tests/core.rs`).
+
+<!-- gh-id: 3270931181 -->
+### Copilot on [`tests/core/i016.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931181) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale/counterexample location (e.g., `tests/core/u008.rs` or `tests/core.rs`).
+
+<!-- gh-id: 3270931193 -->
+### Copilot on [`tests/core/i008.rs:2`](https://github.com/cmk/connections/pull/7#discussion_r3270931193) (2026-05-20 02:44 UTC)
+
+The header comment points to `tests/core/u8_galois.rs`, but that file doesn't exist in `tests/core/`. Please update the reference to an existing rationale/counterexample location (e.g., `tests/core/u008.rs` or `tests/core.rs`).
+
+<!-- gh-id: 3270931208 -->
+### Copilot on [`src/core/i016.rs:85`](https://github.com/cmk/connections/pull/7#discussion_r3270931208) (2026-05-20 02:44 UTC)
+
+`I016KV02` is a new KV (lex-key) encoding iso, but this module’s test suite doesn’t exercise it (unlike `I008KV01`, which has boundary + order-preservation properties). Please add at least basic round-trip + boundary-byte checks and an order/lex-compare property for `I016KV02` to avoid regressions in the bias constant or endianness.
+
+<!-- gh-id: 3270931225 -->
+### Copilot on [`src/core/i032.rs:86`](https://github.com/cmk/connections/pull/7#discussion_r3270931225) (2026-05-20 02:44 UTC)
+
+`I032KV04` is a new KV (lex-key) encoding iso, but this module’s test suite doesn’t exercise it. Please add round-trip + boundary-byte checks and an order/lex-compare property (as done for `I008KV01`) to catch mistakes in the bias constant or endianness.
+
+<!-- gh-id: 3270931239 -->
+### Copilot on [`src/core/i064.rs:87`](https://github.com/cmk/connections/pull/7#discussion_r3270931239) (2026-05-20 02:44 UTC)
+
+`I064KV08` is a new KV (lex-key) encoding iso, but this module’s test suite doesn’t exercise it. Please add round-trip + boundary-byte checks and an order/lex-compare property (as done for `I008KV01`) so the bias constant/endian shape can’t drift silently.
+
+<!-- gh-id: 3270931258 -->
+### Copilot on [`src/core/i128.rs:90`](https://github.com/cmk/connections/pull/7#discussion_r3270931258) (2026-05-20 02:44 UTC)
+
+`I128KV16` is a new KV (lex-key) encoding iso, but this module’s test suite doesn’t exercise it. Please add round-trip + boundary-byte checks and an order/lex-compare property (as done for `I008KV01`) to guard the bias constant/endian encoding.
+
+<!-- gh-id: 4324819909 -->
+### copilot-pull-request-reviewer[bot] — COMMENTED ([2026-05-20 02:44 UTC](https://github.com/cmk/connections/pull/7#pullrequestreview-4324819909))
+
+## Pull request overview
+
+This PR is a pre-publish polish pass for the `connections` crate that extends the crate’s numeric-encoding ladder with KV-store-sortable signed-int key encodings, fills in NonZero widening/narrowing Conn families via new macros, and cleans up assorted drift and documentation issues (including kani harness import paths and hifi doc comment artifacts).
+
+**Changes:**
+- Added `core::KV<N>` and new signed-int `IxxxKVyy` isos producing lex-orderable big-endian key bytes for KV stores.
+- Added NonZero Conn macro families (`nz_uint_widen!`, `nz_int_narrow!`, `nz_uint_narrow!`) and instantiated the corresponding `N###N###` Conns across u8..u128 / i16..i128.
+- Swept polish/drift fixes across kani harnesses, docs tables/re-exports, and various test/doc comments.
+
+### Reviewed changes
+
+Copilot reviewed 44 out of 44 changed files in this pull request and generated 20 comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File | Description |
+| ---- | ----------- |
+| tests/fixed/u128.rs | Updates header docs for fixed u128 proptest battery. |
+| tests/fixed/u064.rs | Updates header docs for fixed u64 proptest battery. |
+| tests/fixed/u032.rs | Updates header docs for fixed u32 proptest battery. |
+| tests/fixed/u016.rs | Updates header docs for fixed u16 proptest battery. |
+| tests/fixed/u008.rs | Updates header docs for fixed u8 proptest battery. |
+| tests/core/u128.rs | Updates header docs for core u128 proptest battery. |
+| tests/core/u064.rs | Updates header docs for core u64 proptest battery. |
+| tests/core/u032.rs | Updates header docs for core u32 proptest battery. |
+| tests/core/u016.rs | Updates header docs for core u16 proptest battery. |
+| tests/core/u008.rs | Updates header docs for core u8 proptest battery. |
+| tests/core/i128.rs | Updates header docs for core i128 proptest battery. |
+| tests/core/i064.rs | Updates header docs for core i64 proptest battery. |
+| tests/core/i032.rs | Updates header docs for core i32 proptest battery. |
+| tests/core/i016.rs | Updates header docs for core i16 proptest battery. |
+| tests/core/i008.rs | Updates header docs for core i8 proptest battery. |
+| src/lib.rs | Fixes F016 path in the public naming table; extends macro table and macro re-exports. |
+| src/kani/uint_widen.rs | Rewires kani harness imports to `crate::core::*` after the core/fixed split; reorganizes by source module. |
+| src/kani/uint_sat.rs | Rewires kani harness imports to `crate::core::*` and groups by source module. |
+| src/kani/uint_narrow.rs | Rewires kani harness imports to `crate::core::*` and groups by source module. |
+| src/kani/nz_ext.rs | Fixes stale kani import paths for NonZero extension Conns. |
+| src/kani/int_narrow.rs | Fixes stale kani import paths for int narrowing Conns. |
+| src/kani/ext_int.rs | Fixes stale kani import paths for Extended-source widening Conns; reorganizes by source. |
+| src/interval.rs | Adds `Hash` derive to `Interval<A>`. |
+| src/hifi/epoch.rs | Removes stale GitLab MR parenthetical references from doc comments/tests. |
+| src/hifi/duration.rs | Removes stale GitLab MR parenthetical references from doc comments/tests. |
+| src/hifi/calendar.rs | Fixes stale module path in docs and removes GitLab MR parentheticals. |
+| src/hifi.rs | Fixes stale module path reference in docs. |
+| src/float.rs | Adds `float::F016` alias (feature-gated) and docsrs cfg mirror. |
+| src/fixed.rs | Removes stale “migration/backward-compat” documentation text. |
+| src/core/u128.rs | Adds `nz_uint_narrow!` instantiations (N128N###) and proptests. |
+| src/core/u064.rs | Adds `nz_uint_narrow!` (N064N###) + `nz_uint_widen!` (N064N128) and proptests. |
+| src/core/u032.rs | Adds `nz_uint_narrow!` (N032N###) + `nz_uint_widen!` and proptests. |
+| src/core/u016.rs | Adds `nz_uint_narrow!` (N016N008) + `nz_uint_widen!` and spot/property tests. |
+| src/core/u008.rs | Adds `nz_uint_widen!` instantiations (N008N###) and spot/property tests. |
+| src/core/i128.rs | Adds `nz_int_narrow!` (N128N###) and `I128KV16` iso. |
+| src/core/i064.rs | Adds `nz_int_narrow!` (N064N###) and `I064KV08` iso. |
+| src/core/i032.rs | Adds `nz_int_narrow!` (N032N###) and `I032KV04` iso. |
+| src/core/i016.rs | Adds `nz_int_narrow!` (N016N008) and `I016KV02` iso. |
+| src/core/i008.rs | Adds `I008KV01` iso plus boundary/roundtrip/Galois/order-preservation property tests. |
+| src/core/f064.rs | Improves doctest assertions and adds docsrs cfg mirror for f16-gated item. |
+| src/core/f032.rs | Improves doctest assertions and adds docsrs cfg mirror for f16-gated item. |
+| src/core.rs | Introduces `KV<N>` wrapper and adds the new NonZero widening/narrowing macros (and rationale for no `nz_int_widen!`). |
+| doc/reviews/review-00007.md | Audit-trail review record (out of review scope per repo rules). |
+| doc/plans/plan-2026-05-19-02.md | Adds the sprint plan describing KV + NonZero macro work and associated polish. |
+</details>
+
+
+
+
+
+
+
+<!-- gh-id: 3270931271 -->
+### Copilot on [`doc/plans/plan-2026-05-19-02.md:18`](https://github.com/cmk/connections/pull/7#discussion_r3270931271) (2026-05-20 02:44 UTC)
+
+This plan still contains a few now-stale technical details that conflict with the shipped diff:
+- Line 15 has a typo in the type mapping (`NonZeroUN> → NonZeroUM`).
+- The KV snippet (lines 54–55) includes `Default`, but `KV<N>` in `src/core.rs` intentionally does not derive `Default` (see the later “Design deviations” note).
+- The `nz_uint_widen!` signature here (lines 107–112) still shows a 3-arg form, but the macro in `src/core.rs` takes 5 args.
+Please update these earlier sections so readers don’t copy/paste incorrect signatures/derives even if they miss the later review notes.
+
+
+<!-- gh-id: 3271186151 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271186151))
+
+Fixed — repointed to `tests/fixed/u008.rs` (the actual rationale file; the `_galois` suffix was a pre-restructure stale ref).
+
+<!-- gh-id: 3271186337 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271186337))
+
+Fixed — repointed to `tests/fixed/u008.rs` (the actual rationale file; the `_galois` suffix was a pre-restructure stale ref).
+
+<!-- gh-id: 3271186579 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271186579))
+
+Fixed — repointed to `tests/fixed/u008.rs` (the actual rationale file; the `_galois` suffix was a pre-restructure stale ref).
+
+<!-- gh-id: 3271186786 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271186786))
+
+Fixed — repointed to `tests/fixed/u008.rs` (the actual rationale file; the `_galois` suffix was a pre-restructure stale ref). Also corrected the `src/conn/fixed/u016.rs` path to `src/fixed/u016.rs`.
+
+<!-- gh-id: 3271186965 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271186965))
+
+Fixed — rewrote the header to reflect the actual integration-test layout (mounted from `tests/fixed.rs` aggregator via `#[path]`, not separate standalone rustc invocations) and corrected the spot-test path to `src/fixed/u008.rs`.
+
+<!-- gh-id: 3271187300 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271187300))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271187461 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271187461))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271187744 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271187744))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271187942 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271187942))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271188189 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271188189))
+
+Fixed — cross-tree precedent ref updated from `tests/fixed/u<width>_galois.rs` to `tests/fixed/u008.rs` (the actual rationale file).
+
+<!-- gh-id: 3271188512 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271188512))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271188718 -->
+#### ↳ cmk ([2026-05-20 04:18 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271188718))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271188962 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271188962))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271189154 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271189154))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271189365 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271189365))
+
+Fixed — repointed to `tests/core/u008.rs` (the canonical core rationale file).
+
+<!-- gh-id: 3271189893 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271189893))
+
+Fixed — added the I016LX02 battery: boundary bytes, iso-roundtrip-l, roundtrip-ceil, galois L/R, floor_le_ceil, and signed-cmp ⟺ raw-byte lex compare. Mirrors I008LX01.
+
+<!-- gh-id: 3271190108 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271190108))
+
+Fixed — added the I032LX04 battery (same shape as I008LX01: boundary bytes + iso-roundtrip + galois L/R + floor_le_ceil + signed-cmp ⟺ raw-byte lex compare).
+
+<!-- gh-id: 3271190296 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271190296))
+
+Fixed — added the I064LX08 battery (same shape as I008LX01).
+
+<!-- gh-id: 3271190441 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271190441))
+
+Fixed — added the I128LX16 battery (same shape as I008LX01).
+
+<!-- gh-id: 3271190604 -->
+#### ↳ cmk ([2026-05-20 04:19 UTC](https://github.com/cmk/connections/pull/7#discussion_r3271190604))
+
+Fixed all three:
+- Dropped the stray `>` from the type mapping (now `NonZeroUN → NonZeroUM`).
+- Removed `Default` from the `LX<N>` snippet and added an inline note explaining why (`[u8; N]: Default` only for N ≤ 32 in const-generic-free form, and sibling wrappers don't have it either).
+- Updated `nz_uint_widen!` to the 5-arg form (`NAME, NZN, UN, NZM, UM`) — extra primitives needed for the saturation `as`-cast.

--- a/src/core.rs
+++ b/src/core.rs
@@ -213,6 +213,46 @@ impl<const N: usize> AsRef<[u8; N]> for L2<N> {
     }
 }
 
+/// Byte-array wrapper whose default-derived `Ord` is raw
+/// lexicographic compare over the bytes.
+///
+/// `LX<N>` itself does no encoding or decoding — it just carries
+/// the contract that comparison walks the bytes left-to-right.
+/// Producers that want numeric-equivalent ordering ship Conns
+/// (`IxxxLXxy` in `src/core/iNNN.rs`) that bias signed inputs by
+/// `1 << (bits-1)` before big-endian encoding so the stored bytes
+/// sort numerically; consumers that just want lex ordering over
+/// arbitrary bytes can use the wrapper directly.
+///
+/// Typical consumers are byte-keyed stores (LMDB, RocksDB, sled,
+/// etc.) that compare keys directly without consulting Rust's
+/// `Ord`, and sorted in-memory containers where the lex contract
+/// is explicit. For 2s-complement preservation use [`B2`] / [`L2`].
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct LX<const N: usize>(pub [u8; N]);
+
+impl<const N: usize> From<[u8; N]> for LX<N> {
+    #[inline]
+    fn from(bytes: [u8; N]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl<const N: usize> From<LX<N>> for [u8; N] {
+    #[inline]
+    fn from(bytes: LX<N>) -> Self {
+        bytes.0
+    }
+}
+
+impl<const N: usize> AsRef<[u8; N]> for LX<N> {
+    #[inline]
+    fn as_ref(&self) -> &[u8; N] {
+        &self.0
+    }
+}
+
 #[cfg(test)]
 mod le_tests {
     use super::{B2, L2, LE};
@@ -617,6 +657,74 @@ macro_rules! nz_uint_ext {
 }
 pub(crate) use nz_uint_ext;
 
+/// `Conn<NonZero<u_N>, NonZero<u_M>>` widening
+/// (`bits(u_N) < bits(u_M)`).
+///
+/// Mirrors [`uint_uint!`] at the [`NonZero`](core::num) layer.
+/// `ceil` lossless-widens via `n.get() as $UM`; the result is never
+/// zero because `NonZero<u_N>.get() ≥ 1`. `inner` saturates targets
+/// above `u_N::MAX` down to `NonZero<u_N>::new(u_N::MAX)`. The zero
+/// gap of [`nz_uint_ext!`] doesn't appear here — `NonZero<u_M>.get()
+/// ≥ 1`, so the clipped value is always `≥ 1` after the saturation,
+/// and `NonZero<u_N>::new` succeeds without panic.
+///
+/// Single-sided left-Galois ([`Conn::new_l`]) — the saturation
+/// plateau at `NonZero<u_N>::MAX` lives on the source side.
+///
+/// [`Conn::new_l`]: crate::conn::Conn::new_l
+/// [`uint_uint!`]: crate::uint_uint
+/// [`nz_uint_ext!`]: crate::nz_uint_ext
+#[cfg_attr(feature = "macros", macro_export)]
+macro_rules! nz_uint_widen {
+    ($NAME:ident, $NZN:ty, $UN:ty, $NZM:ty, $UM:ty) => {
+#[rustfmt::skip]
+        #[doc = concat!(
+            "`",
+            stringify!($NZN),
+            " → ",
+            stringify!($NZM),
+            "` lossless widening; `inner` saturates at `",
+            stringify!($NZN),
+            "::MAX`."
+        )]
+        pub const $NAME: $crate::conn::Conn<$NZN, $NZM> = {
+            fn ceil(n: $NZN) -> $NZM {
+                match <$NZM>::new(n.get() as $UM) {
+                    Some(nz) => nz,
+                    // unreachable: NZN::get() ≥ 1, cast preserves value
+                    None => panic!("nz_uint_widen::ceil produced zero"),
+                }
+            }
+            fn inner(m: $NZM) -> $NZN {
+                let cap = <$UN>::MAX as $UM;
+                let val = m.get();
+                let clipped = if val > cap { cap } else { val };
+                match <$NZN>::new(clipped as $UN) {
+                    Some(nz) => nz,
+                    // unreachable: clipped ≥ NZM::get() ≥ 1, cap ≥ 1
+                    None => panic!("nz_uint_widen::inner produced zero"),
+                }
+            }
+            $crate::conn::Conn::new_l(ceil, inner)
+        };
+    };
+}
+pub(crate) use nz_uint_widen;
+
+// No `nz_int_widen!`. Signed `NonZero<i_N> → NonZero<i_M>` (N < M)
+// cannot be expressed as a bare `Conn<NonZero<i_N>, NonZero<i_M>>`:
+// the target side has plateaus on *both* ends (values in
+// `[i_M::MIN, i_N::MIN as i_M - 1]` below the source range, and
+// `[i_N::MAX as i_M + 1, i_M::MAX]` above it). Closing the lower
+// plateau requires a `-Inf` sentinel on the source — which
+// `NonZero<i_N>` does not provide — so no `inner` choice satisfies
+// L-Galois on the lower plateau. R-Galois fails symmetrically on the
+// upper plateau. Compare `nz_uint_widen!`, where the unsigned lower
+// bound `u_N::MIN = 0 < 1 = NonZero<u_M>::MIN` makes the lower
+// plateau empty and saturation is sound. Use `nz_int_ext!` +
+// `ext_int!` to widen via `i_N -> Extended<i_N> -> i_M ->
+// NonZero<i_M>` when needed.
+
 /// `Conn<i_N, u_M>` narrowing (`bits(i_N) > bits(u_M)`).
 ///
 /// `ceil` clips negatives to `0` and saturates positives at
@@ -646,6 +754,141 @@ macro_rules! int_uint_narrow {
     };
 }
 pub(crate) use int_uint_narrow;
+
+/// `Conn<NonZero<i_N>, NonZero<i_M>>` narrowing
+/// (`bits(i_N) > bits(i_M)`).
+///
+/// Mirrors [`int_int_narrow!`] at the signed [`NonZero`](core::num)
+/// layer. `ceil` saturates source values above `i_M::MAX` to
+/// `i_M::MAX` and below `i_M::MIN` to `i_M::MIN` (both nonzero, so
+/// no zero gap reappears). `inner` is the lossless `as`-widen with a
+/// FINE_MAX fixup (`inner(i_M::MAX) = i_N::MAX`).
+///
+/// **Why no FINE_MIN fixup?** Same argument as [`int_int_narrow!`]:
+/// the low-end source plateau covers every `a < i_M::MIN as i_N`,
+/// where `ceil(a) = i_M::MIN ≤ b` is always true and
+/// `inner(b) ≥ i_M::MIN as i_N > a` is always true (since
+/// `i_M::MIN as i_N > i_N::MIN ≥ a` by the bit-width constraint),
+/// so the law's LHS and RHS match without a fixup. Compare the high
+/// end, where `ceil` collapsing onto `i_M::MAX` does require the
+/// fixup so `a ≤ inner(i_M::MAX) = i_N::MAX` holds.
+///
+/// Single-sided left-Galois ([`Conn::new_l`]).
+///
+/// [`Conn::new_l`]: crate::conn::Conn::new_l
+/// [`int_int_narrow!`]: crate::int_int_narrow
+#[cfg_attr(feature = "macros", macro_export)]
+macro_rules! nz_int_narrow {
+    ($NAME:ident, $NZN:ty, $IN:ty, $NZM:ty, $IM:ty) => {
+#[rustfmt::skip]
+        #[doc = concat!(
+            "`",
+            stringify!($NZN),
+            " → ",
+            stringify!($NZM),
+            "` saturating narrow; `inner` widens with FINE_MAX fixup at `",
+            stringify!($NZM),
+            "::MAX`."
+        )]
+        pub const $NAME: $crate::conn::Conn<$NZN, $NZM> = {
+            fn ceil(n: $NZN) -> $NZM {
+                let val = n.get();
+                let clipped = if val > <$IM>::MAX as $IN {
+                    <$IM>::MAX
+                } else if val < <$IM>::MIN as $IN {
+                    <$IM>::MIN
+                } else {
+                    val as $IM
+                };
+                match <$NZM>::new(clipped) {
+                    Some(nz) => nz,
+                    // unreachable: IN value != 0, clipped takes IM::MIN / IM::MAX /
+                    // (val as IM); IM::MIN < 0 < IM::MAX, and val in [IM::MIN, IM::MAX]
+                    // preserves nonzero-ness.
+                    None => panic!("nz_int_narrow::ceil produced zero"),
+                }
+            }
+            fn inner(m: $NZM) -> $NZN {
+                let v: $IN = if m.get() == <$IM>::MAX {
+                    <$IN>::MAX
+                } else {
+                    m.get() as $IN
+                };
+                match <$NZN>::new(v) {
+                    Some(nz) => nz,
+                    // unreachable: m.get() != 0; widen preserves nonzero
+                    None => panic!("nz_int_narrow::inner produced zero"),
+                }
+            }
+            $crate::conn::Conn::new_l(ceil, inner)
+        };
+    };
+}
+pub(crate) use nz_int_narrow;
+
+/// `Conn<NonZero<u_N>, NonZero<u_M>>` narrowing
+/// (`bits(u_N) > bits(u_M)`).
+///
+/// Mirrors [`uint_uint_narrow!`] at the unsigned
+/// [`NonZero`](core::num) layer. `ceil` saturates source values
+/// above `u_M::MAX` to `u_M::MAX` (nonzero) before downcasting. No
+/// low-end branch: source values start at `NonZero<u_N> ≥ 1`, and
+/// `u_M::MIN = 0 < 1`, so no source value can fall below the target's
+/// minimum representable. The zero gap of [`nz_uint_ext!`] doesn't
+/// reappear here — both endpoints' NonZero range is `[1, ::MAX]`.
+///
+/// `inner` is the lossless `as`-widen with a FINE_MAX fixup
+/// (`inner(u_M::MAX) = u_N::MAX`).
+///
+/// Single-sided left-Galois ([`Conn::new_l`]).
+///
+/// [`Conn::new_l`]: crate::conn::Conn::new_l
+/// [`uint_uint_narrow!`]: crate::uint_uint_narrow
+/// [`nz_uint_ext!`]: crate::nz_uint_ext
+#[cfg_attr(feature = "macros", macro_export)]
+macro_rules! nz_uint_narrow {
+    ($NAME:ident, $NZN:ty, $UN:ty, $NZM:ty, $UM:ty) => {
+#[rustfmt::skip]
+        #[doc = concat!(
+            "`",
+            stringify!($NZN),
+            " → ",
+            stringify!($NZM),
+            "` saturating narrow; `inner` widens with FINE_MAX fixup at `",
+            stringify!($NZM),
+            "::MAX`."
+        )]
+        pub const $NAME: $crate::conn::Conn<$NZN, $NZM> = {
+            fn ceil(n: $NZN) -> $NZM {
+                let val = n.get();
+                let clipped = if val > <$UM>::MAX as $UN {
+                    <$UM>::MAX
+                } else {
+                    val as $UM
+                };
+                match <$NZM>::new(clipped) {
+                    Some(nz) => nz,
+                    // unreachable: UN value ≥ 1, clipped ∈ [1, UM::MAX]
+                    None => panic!("nz_uint_narrow::ceil produced zero"),
+                }
+            }
+            fn inner(m: $NZM) -> $NZN {
+                let v: $UN = if m.get() == <$UM>::MAX {
+                    <$UN>::MAX
+                } else {
+                    m.get() as $UN
+                };
+                match <$NZN>::new(v) {
+                    Some(nz) => nz,
+                    // unreachable: m.get() ≥ 1; widen preserves nonzero
+                    None => panic!("nz_uint_narrow::inner produced zero"),
+                }
+            }
+            $crate::conn::Conn::new_l(ceil, inner)
+        };
+    };
+}
+pub(crate) use nz_uint_narrow;
 
 // ── Per-primitive submodules ───────────────────────────────────────
 

--- a/src/core/f032.rs
+++ b/src/core/f032.rs
@@ -42,19 +42,25 @@ fn f032f016_floor(x: F032) -> F016 {
 }
 
 #[cfg(feature = "f16")]
+#[cfg_attr(docsrs, doc(cfg(feature = "f16")))]
 crate::conn_k! {
     /// Connection between [`crate::float::F032`] and [`super::f016::F016`].
     ///
     /// ```
     /// # #![feature(f16)]
     /// use connections::core::f032::F032F016;
-    /// use connections::float::{ExtendedFloat::Extend, F032};
+    /// use connections::float::ExtendedFloat::Extend;
     ///
-    /// let pi = Extend(std::f32::consts::PI);
-    /// let pi_up = F032F016.ceil(pi);
-    /// let pi_down = F032F016.floor(pi);
-    /// assert!(F032F016.upper(pi_down) <= pi);
-    /// assert!(pi <= F032F016.upper(pi_up));
+    /// // PI's two nearest f16 grid points (spacing 2^-9 in [2, 4)).
+    /// let pi_f32 = Extend(std::f32::consts::PI);
+    /// let pi_f16_floor = Extend(3.140_625_f16);
+    /// let pi_f16_ceil  = Extend(3.142_578_125_f16);
+    ///
+    /// assert_eq!(F032F016.floor(pi_f32), pi_f16_floor);
+    /// assert_eq!(F032F016.ceil(pi_f32),  pi_f16_ceil);
+    /// // Widening lifts each grid point to its f32 image exactly:
+    /// assert_eq!(F032F016.upper(pi_f16_floor), Extend(3.140_625_f32));
+    /// assert_eq!(F032F016.upper(pi_f16_ceil),  Extend(3.142_578_125_f32));
     /// ```
     pub F032F016 : F032 => F016 {
         ceil:  f032f016_ceil,

--- a/src/core/f064.rs
+++ b/src/core/f064.rs
@@ -57,6 +57,7 @@ fn f064f016_floor(x: F064) -> F016 {
 }
 
 #[cfg(feature = "f16")]
+#[cfg_attr(docsrs, doc(cfg(feature = "f16")))]
 crate::conn_k! {
     /// Direct `f64 ↔ f16` narrowing under the N5 lattice.
     ///
@@ -65,9 +66,13 @@ crate::conn_k! {
     /// use connections::core::f064::F064F016;
     /// use connections::float::ExtendedFloat::Extend;
     ///
-    /// let pi = Extend(std::f64::consts::PI);
-    /// let pi_up = F064F016.ceil(pi);
-    /// assert!(F064F016.upper(pi_up) >= pi);
+    /// // PI's f16 ceiling — the next f16 grid point above PI.
+    /// let pi_f64 = Extend(std::f64::consts::PI);
+    /// let pi_f16_ceil = Extend(3.142_578_125_f16);
+    ///
+    /// assert_eq!(F064F016.ceil(pi_f64), pi_f16_ceil);
+    /// // Widening back to f64 picks up the f16 grid point exactly:
+    /// assert_eq!(F064F016.upper(pi_f16_ceil), Extend(3.142_578_125_f64));
     /// ```
     pub F064F016 : F064 => F016 {
         ceil:  f064f016_ceil,
@@ -101,18 +106,23 @@ crate::conn_k! {
     /// ```rust
     /// use connections::conn::{ConnL, ConnR};
     /// use connections::core::f064::F064F032;
+    /// use connections::float::ExtendedFloat::Extend;
+    ///
+    /// // PI in f64-precision and the two f32 grid points that bracket it.
+    /// // The error term `pi32_err ≈ +8.74e-8` is the f32 round-off on PI.
+    /// let pi_f64 = Extend(std::f64::consts::PI);
+    /// let pi_f32_floor = Extend(3.141_592_502_593_994_f64);
+    /// let pi_f32_ceil  = Extend(std::f32::consts::PI as f64);
+    ///
+    /// assert_eq!(F064F032.floor(pi_f64), Extend(3.141_592_502_593_994_f64 as f32));
+    /// assert_eq!(F064F032.ceil(pi_f64),  Extend(std::f32::consts::PI));
+    /// // Widening lifts each f32 grid point to its exact f64 image.
+    /// assert_eq!(F064F032.upper(F064F032.floor(pi_f64)), pi_f32_floor);
+    /// assert_eq!(F064F032.upper(F064F032.ceil(pi_f64)),  pi_f32_ceil);
+    ///
+    /// // Sentinel pass-through.
     /// use connections::float::ExtendedFloat;
-    ///
-    /// let pi_f64 = ExtendedFloat::Extend(core::f64::consts::PI);
-    /// let lo = F064F032.floor(pi_f64);
-    /// let hi = F064F032.ceil(pi_f64);
-    /// assert!(matches!(lo, ExtendedFloat::Extend(_)));
-    /// assert!(matches!(hi, ExtendedFloat::Extend(_)));
-    /// let lo_back = F064F032.upper(lo);
-    /// let hi_back = F064F032.upper(hi);
-    /// assert!(lo_back <= pi_f64 && pi_f64 <= hi_back);
-    ///
-    /// assert_eq!(F064F032.ceil(ExtendedFloat::Bot), ExtendedFloat::Bot);
+    /// assert_eq!(F064F032.ceil(ExtendedFloat::Bot),  ExtendedFloat::Bot);
     /// assert_eq!(F064F032.floor(ExtendedFloat::Top), ExtendedFloat::Top);
     /// ```
     pub F064F032 : F064 => F032 {

--- a/src/core/i008.rs
+++ b/src/core/i008.rs
@@ -5,7 +5,7 @@
 //! `crate::fixed::i008`.
 
 #[allow(unused_imports)]
-use crate::core::{B2, L2};
+use crate::core::{B2, L2, LX};
 use crate::core::{ext_int, int_uint, nz_int_ext};
 use ::core::num::NonZeroI8;
 
@@ -73,6 +73,45 @@ crate::iso! {
     pub I008LE01 : i8 => L2<1> {
         forward: i8_to_le01,
         back:    le01_to_i8,
+    }
+}
+
+// ── Lex-key big-endian encoding (LX) ──────────────────────────────
+
+const fn i8_to_lx01(x: i8) -> LX<1> {
+    LX([(x as u8).wrapping_add(0x80)])
+}
+const fn lx01_to_i8(b: LX<1>) -> i8 {
+    b.0[0].wrapping_sub(0x80) as i8
+}
+
+crate::iso! {
+    /// `i8 ↔ LX<1>` — bias-encoded big-endian iso whose raw byte
+    /// `Ord` matches signed numeric order.
+    ///
+    /// Encoder maps `x: i8` to `[(x as u8).wrapping_add(0x80)]`: the
+    /// sign-bit flip turns signed values into unsigned values whose
+    /// big-endian byte representation is directly lex-sortable. Use
+    /// this rather than [`I008BE01`] when the consumer compares bytes
+    /// without a custom `Ord` — byte-keyed stores, on-disk sorted indices, etc.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use connections::conn::{ConnL, ConnR};
+    /// use connections::core::LX;
+    /// use connections::core::i008::I008LX01;
+    ///
+    /// assert_eq!(I008LX01.ceil(i8::MIN), LX([0x00]));
+    /// assert_eq!(I008LX01.ceil(0_i8),    LX([0x80]));
+    /// assert_eq!(I008LX01.ceil(i8::MAX), LX([0xFF]));
+    /// // Raw byte lex compare matches signed numeric compare.
+    /// assert!(I008LX01.ceil(i8::MIN) < I008LX01.ceil(0));
+    /// assert!(I008LX01.ceil(0)       < I008LX01.ceil(i8::MAX));
+    /// ```
+    pub I008LX01 : i8 => LX<1> {
+        forward: i8_to_lx01,
+        back:    lx01_to_i8,
     }
 }
 
@@ -284,6 +323,69 @@ mod tests {
         #[test]
         fn i008_l2_order_preserving(a in any::<i8>(), b in any::<i8>()) {
             prop_assert_eq!(a.cmp(&b), I008LE01.ceil(a).cmp(&I008LE01.ceil(b)));
+        }
+    }
+
+    // ── LX (lex-sortable big-endian) byte-encoding tests ──────────
+
+    fn arb_lxbyte1() -> impl Strategy<Value = LX<1>> {
+        prop_oneof![
+            Just([0; 1]),
+            Just([0x80]),
+            Just([0xFF; 1]),
+            any::<[u8; 1]>()
+        ]
+        .prop_map(LX)
+    }
+
+    #[test]
+    fn i008lx01_boundary_bytes() {
+        // Bias-encoded boundaries: MIN→0x00, 0→0x80, MAX→0xFF.
+        // Raw byte lex compare matches signed numeric order.
+        assert_eq!(I008LX01.ceil(i8::MIN), LX([0x00]));
+        assert_eq!(I008LX01.ceil(0_i8), LX([0x80]));
+        assert_eq!(I008LX01.ceil(i8::MAX), LX([0xFF]));
+        assert_eq!(I008LX01.upper(LX([0x00])), i8::MIN);
+        assert_eq!(I008LX01.upper(LX([0x80])), 0_i8);
+        assert_eq!(I008LX01.upper(LX([0xFF])), i8::MAX);
+    }
+
+    proptest! {
+        #[test]
+        fn i008_lx_iso_roundtrip_l(
+            a in prop_oneof![Just(i8::MIN), Just(0i8), Just(i8::MAX), any::<i8>()]
+        ) {
+            prop_assert!(conn_laws::iso_roundtrip_l(&I008LX01.conn_l(), a));
+        }
+
+        #[test]
+        fn i008_lx_roundtrip_ceil(b in arb_lxbyte1()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&I008LX01.conn_l(), b));
+        }
+
+        #[test]
+        fn i008_lx_galois_l(a in any::<i8>(), b in arb_lxbyte1()) {
+            prop_assert!(conn_laws::galois_l(&I008LX01.conn_l(), a, b));
+        }
+
+        #[test]
+        fn i008_lx_galois_r(a in any::<i8>(), b in arb_lxbyte1()) {
+            prop_assert!(conn_laws::galois_r(&I008LX01.conn_r(), a, b));
+        }
+
+        #[test]
+        fn i008_lx_floor_le_ceil(a in any::<i8>()) {
+            prop_assert!(conn_laws::floor_le_ceil(&I008LX01, a));
+        }
+
+        // The I008LX01 contract: signed numeric compare ⟺ raw byte
+        // lex compare on the bias-encoded bytes. This is the whole
+        // point of the bias-encoding Conn.
+        #[test]
+        fn i008_lx_signed_cmp_matches_raw_byte_cmp(a in any::<i8>(), b in any::<i8>()) {
+            let ka = I008LX01.ceil(a).0;
+            let kb = I008LX01.ceil(b).0;
+            prop_assert_eq!(a.cmp(&b), ka.cmp(&kb));
         }
     }
 }

--- a/src/core/i016.rs
+++ b/src/core/i016.rs
@@ -5,9 +5,9 @@
 //! `crate::fixed::i016`.
 
 #[allow(unused_imports)]
-use crate::core::{B2, L2};
-use crate::core::{ext_int, int_int_narrow, int_uint, int_uint_narrow, nz_int_ext};
-use ::core::num::NonZeroI16;
+use crate::core::{B2, L2, LX};
+use crate::core::{ext_int, int_int_narrow, int_uint, int_uint_narrow, nz_int_ext, nz_int_narrow};
+use ::core::num::{NonZeroI8, NonZeroI16};
 
 // ── §1 std-int Conns sourced from `i16` ───────────────────────────
 
@@ -25,6 +25,10 @@ int_uint!(I016U128, i16, u128);
 // ── §3 i16 ↔ NonZeroI16 ───────────────────────────────────────────
 
 nz_int_ext!(I016N016, i16, NonZeroI16);
+
+// ── NonZero signed narrowings ─────────────────────────────────────
+
+nz_int_narrow!(N016N008, NonZeroI16, i16, NonZeroI8, i8);
 
 // ── Two's-complement big-endian byte encodings ────────────────────
 
@@ -57,6 +61,27 @@ crate::iso! {
     pub I016LE02 : i16 => L2<2> {
         forward: i16_to_le02,
         back:    le02_to_i16,
+    }
+}
+
+// ── Lex-key big-endian encoding (LX) ──────────────────────────────
+
+const fn i16_to_lx02(x: i16) -> LX<2> {
+    LX((x as u16).wrapping_add(0x8000).to_be_bytes())
+}
+const fn lx02_to_i16(b: LX<2>) -> i16 {
+    u16::from_be_bytes(b.0).wrapping_sub(0x8000) as i16
+}
+
+crate::iso! {
+    /// `i16 ↔ LX<2>` — bias-encoded big-endian iso whose raw byte
+    /// `Ord` matches signed numeric order. See [`I008LX01`] for the
+    /// design rationale.
+    ///
+    /// [`I008LX01`]: crate::core::i008::I008LX01
+    pub I016LX02 : i16 => LX<2> {
+        forward: i16_to_lx02,
+        back:    lx02_to_i16,
     }
 }
 
@@ -142,6 +167,41 @@ mod tests {
         assert_eq!(U128I016.floor(u128::MAX), i16::MAX);
     }
 
+    // ── NonZero signed narrowing (N016N008) spot + property ───────
+
+    fn arb_nz_i8() -> impl Strategy<Value = NonZeroI8> {
+        any::<i8>().prop_filter_map("non-zero i8", NonZeroI8::new)
+    }
+    fn arb_nz_i16() -> impl Strategy<Value = NonZeroI16> {
+        any::<i16>().prop_filter_map("non-zero i16", NonZeroI16::new)
+    }
+
+    #[test]
+    fn n016n008_saturates_both_plateaus() {
+        let big_pos = NonZeroI16::new(i16::MAX).unwrap();
+        let big_neg = NonZeroI16::new(i16::MIN).unwrap();
+        let in_range = NonZeroI16::new(42).unwrap();
+        assert_eq!(N016N008.ceil(big_pos), NonZeroI8::new(i8::MAX).unwrap());
+        assert_eq!(N016N008.ceil(big_neg), NonZeroI8::new(i8::MIN).unwrap());
+        assert_eq!(N016N008.ceil(in_range), NonZeroI8::new(42).unwrap());
+        // FINE_MAX fixup: inner(NZ(i8::MAX)) = NZ(i16::MAX)
+        assert_eq!(
+            N016N008.upper(NonZeroI8::new(i8::MAX).unwrap()),
+            NonZeroI16::new(i16::MAX).unwrap()
+        );
+        assert_eq!(
+            N016N008.upper(NonZeroI8::new(i8::MIN).unwrap()),
+            NonZeroI16::new(i8::MIN as i16).unwrap()
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn n016n008_galois_l(a in arb_nz_i16(), b in arb_nz_i8()) {
+            prop_assert!(conn_laws::galois_l(&N016N008.conn_l(), a, b));
+        }
+    }
+
     fn arb_byte2() -> impl Strategy<Value = B2<2>> {
         prop_oneof![Just([0; 2]), Just([0xFF; 2]), any::<[u8; 2]>()].prop_map(B2)
     }
@@ -204,6 +264,61 @@ mod tests {
         #[test]
         fn i016_l2_order_preserving(a in any::<i16>(), b in any::<i16>()) {
             prop_assert_eq!(a.cmp(&b), I016LE02.ceil(a).cmp(&I016LE02.ceil(b)));
+        }
+    }
+
+    // ── LX (lex-sortable big-endian) byte-encoding tests ──────────
+
+    fn arb_lxbyte2() -> impl Strategy<Value = LX<2>> {
+        prop_oneof![
+            Just([0; 2]),
+            Just([0x80, 0x00]),
+            Just([0xFF; 2]),
+            any::<[u8; 2]>()
+        ]
+        .prop_map(LX)
+    }
+
+    #[test]
+    fn i016lx02_boundary_bytes() {
+        assert_eq!(I016LX02.ceil(i16::MIN), LX([0x00, 0x00]));
+        assert_eq!(I016LX02.ceil(0_i16), LX([0x80, 0x00]));
+        assert_eq!(I016LX02.ceil(i16::MAX), LX([0xFF, 0xFF]));
+        assert_eq!(I016LX02.upper(LX([0x00, 0x00])), i16::MIN);
+        assert_eq!(I016LX02.upper(LX([0x80, 0x00])), 0_i16);
+        assert_eq!(I016LX02.upper(LX([0xFF, 0xFF])), i16::MAX);
+    }
+
+    proptest! {
+        #[test]
+        fn i016_lx_iso_roundtrip_l(
+            a in prop_oneof![Just(i16::MIN), Just(0i16), Just(i16::MAX), any::<i16>()]
+        ) {
+            prop_assert!(conn_laws::iso_roundtrip_l(&I016LX02.conn_l(), a));
+        }
+        #[test]
+        fn i016_lx_roundtrip_ceil(b in arb_lxbyte2()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&I016LX02.conn_l(), b));
+        }
+        #[test]
+        fn i016_lx_galois_l(a in any::<i16>(), b in arb_lxbyte2()) {
+            prop_assert!(conn_laws::galois_l(&I016LX02.conn_l(), a, b));
+        }
+        #[test]
+        fn i016_lx_galois_r(a in any::<i16>(), b in arb_lxbyte2()) {
+            prop_assert!(conn_laws::galois_r(&I016LX02.conn_r(), a, b));
+        }
+        #[test]
+        fn i016_lx_floor_le_ceil(a in any::<i16>()) {
+            prop_assert!(conn_laws::floor_le_ceil(&I016LX02, a));
+        }
+        // The I016LX02 contract: signed numeric compare ⟺ raw byte
+        // lex compare on the bias-encoded bytes.
+        #[test]
+        fn i016_lx_signed_cmp_matches_raw_byte_cmp(a in any::<i16>(), b in any::<i16>()) {
+            let ka = I016LX02.ceil(a).0;
+            let kb = I016LX02.ceil(b).0;
+            prop_assert_eq!(a.cmp(&b), ka.cmp(&kb));
         }
     }
 }

--- a/src/core/i032.rs
+++ b/src/core/i032.rs
@@ -5,9 +5,9 @@
 //! `crate::fixed::i032`.
 
 #[allow(unused_imports)]
-use crate::core::{B2, L2};
-use crate::core::{ext_int, int_int_narrow, int_uint, int_uint_narrow, nz_int_ext};
-use ::core::num::NonZeroI32;
+use crate::core::{B2, L2, LX};
+use crate::core::{ext_int, int_int_narrow, int_uint, int_uint_narrow, nz_int_ext, nz_int_narrow};
+use ::core::num::{NonZeroI8, NonZeroI16, NonZeroI32};
 
 // ── §1 std-int Conns sourced from `i32` ───────────────────────────
 
@@ -25,6 +25,11 @@ int_uint!(I032U128, i32, u128);
 // ── §3 i32 ↔ NonZeroI32 ───────────────────────────────────────────
 
 nz_int_ext!(I032N032, i32, NonZeroI32);
+
+// ── NonZero signed narrowings ─────────────────────────────────────
+
+nz_int_narrow!(N032N008, NonZeroI32, i32, NonZeroI8, i8);
+nz_int_narrow!(N032N016, NonZeroI32, i32, NonZeroI16, i16);
 
 // ── Two's-complement big-endian byte encodings ────────────────────
 
@@ -57,6 +62,27 @@ crate::iso! {
     pub I032LE04 : i32 => L2<4> {
         forward: i32_to_le04,
         back:    le04_to_i32,
+    }
+}
+
+// ── Lex-key big-endian encoding (LX) ──────────────────────────────
+
+const fn i32_to_lx04(x: i32) -> LX<4> {
+    LX((x as u32).wrapping_add(0x8000_0000).to_be_bytes())
+}
+const fn lx04_to_i32(b: LX<4>) -> i32 {
+    u32::from_be_bytes(b.0).wrapping_sub(0x8000_0000) as i32
+}
+
+crate::iso! {
+    /// `i32 ↔ LX<4>` — bias-encoded big-endian iso whose raw byte
+    /// `Ord` matches signed numeric order. See [`I008LX01`] for the
+    /// design rationale.
+    ///
+    /// [`I008LX01`]: crate::core::i008::I008LX01
+    pub I032LX04 : i32 => LX<4> {
+        forward: i32_to_lx04,
+        back:    lx04_to_i32,
     }
 }
 
@@ -113,6 +139,29 @@ mod tests {
         assert_eq!(U032I032.lower(-1), 0_u32);
         assert_eq!(U064I032.floor(u64::MAX), i32::MAX);
         assert_eq!(U128I032.lower(i32::MIN), 0_u128);
+    }
+
+    // ── NonZero signed narrowing (N032N###) spot + property ───────
+
+    fn arb_nz_i8() -> impl Strategy<Value = NonZeroI8> {
+        any::<i8>().prop_filter_map("non-zero i8", NonZeroI8::new)
+    }
+    fn arb_nz_i16() -> impl Strategy<Value = NonZeroI16> {
+        any::<i16>().prop_filter_map("non-zero i16", NonZeroI16::new)
+    }
+    fn arb_nz_i32() -> impl Strategy<Value = NonZeroI32> {
+        any::<i32>().prop_filter_map("non-zero i32", NonZeroI32::new)
+    }
+
+    proptest! {
+        #[test]
+        fn n032n008_galois_l(a in arb_nz_i32(), b in arb_nz_i8()) {
+            prop_assert!(conn_laws::galois_l(&N032N008.conn_l(), a, b));
+        }
+        #[test]
+        fn n032n016_galois_l(a in arb_nz_i32(), b in arb_nz_i16()) {
+            prop_assert!(conn_laws::galois_l(&N032N016.conn_l(), a, b));
+        }
     }
 
     fn arb_byte4() -> impl Strategy<Value = B2<4>> {
@@ -177,6 +226,59 @@ mod tests {
         #[test]
         fn i032_l2_order_preserving(a in any::<i32>(), b in any::<i32>()) {
             prop_assert_eq!(a.cmp(&b), I032LE04.ceil(a).cmp(&I032LE04.ceil(b)));
+        }
+    }
+
+    // ── LX (lex-sortable big-endian) byte-encoding tests ──────────
+
+    fn arb_lxbyte4() -> impl Strategy<Value = LX<4>> {
+        prop_oneof![
+            Just([0; 4]),
+            Just([0x80, 0x00, 0x00, 0x00]),
+            Just([0xFF; 4]),
+            any::<[u8; 4]>()
+        ]
+        .prop_map(LX)
+    }
+
+    #[test]
+    fn i032lx04_boundary_bytes() {
+        assert_eq!(I032LX04.ceil(i32::MIN), LX([0x00, 0x00, 0x00, 0x00]));
+        assert_eq!(I032LX04.ceil(0_i32), LX([0x80, 0x00, 0x00, 0x00]));
+        assert_eq!(I032LX04.ceil(i32::MAX), LX([0xFF, 0xFF, 0xFF, 0xFF]));
+        assert_eq!(I032LX04.upper(LX([0x00, 0x00, 0x00, 0x00])), i32::MIN);
+        assert_eq!(I032LX04.upper(LX([0x80, 0x00, 0x00, 0x00])), 0_i32);
+        assert_eq!(I032LX04.upper(LX([0xFF, 0xFF, 0xFF, 0xFF])), i32::MAX);
+    }
+
+    proptest! {
+        #[test]
+        fn i032_lx_iso_roundtrip_l(
+            a in prop_oneof![Just(i32::MIN), Just(0i32), Just(i32::MAX), any::<i32>()]
+        ) {
+            prop_assert!(conn_laws::iso_roundtrip_l(&I032LX04.conn_l(), a));
+        }
+        #[test]
+        fn i032_lx_roundtrip_ceil(b in arb_lxbyte4()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&I032LX04.conn_l(), b));
+        }
+        #[test]
+        fn i032_lx_galois_l(a in any::<i32>(), b in arb_lxbyte4()) {
+            prop_assert!(conn_laws::galois_l(&I032LX04.conn_l(), a, b));
+        }
+        #[test]
+        fn i032_lx_galois_r(a in any::<i32>(), b in arb_lxbyte4()) {
+            prop_assert!(conn_laws::galois_r(&I032LX04.conn_r(), a, b));
+        }
+        #[test]
+        fn i032_lx_floor_le_ceil(a in any::<i32>()) {
+            prop_assert!(conn_laws::floor_le_ceil(&I032LX04, a));
+        }
+        #[test]
+        fn i032_lx_signed_cmp_matches_raw_byte_cmp(a in any::<i32>(), b in any::<i32>()) {
+            let ka = I032LX04.ceil(a).0;
+            let kb = I032LX04.ceil(b).0;
+            prop_assert_eq!(a.cmp(&b), ka.cmp(&kb));
         }
     }
 }

--- a/src/core/i064.rs
+++ b/src/core/i064.rs
@@ -5,9 +5,9 @@
 //! `crate::fixed::i064`.
 
 #[allow(unused_imports)]
-use crate::core::{B2, L2};
-use crate::core::{ext_int, int_int_narrow, int_uint, int_uint_narrow, nz_int_ext};
-use ::core::num::NonZeroI64;
+use crate::core::{B2, L2, LX};
+use crate::core::{ext_int, int_int_narrow, int_uint, int_uint_narrow, nz_int_ext, nz_int_narrow};
+use ::core::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64};
 
 // ── §1 std-int Conns sourced from `i64` ───────────────────────────
 
@@ -25,6 +25,12 @@ int_uint!(I064U128, i64, u128);
 // ── §3 i64 ↔ NonZeroI64 ───────────────────────────────────────────
 
 nz_int_ext!(I064N064, i64, NonZeroI64);
+
+// ── NonZero signed narrowings ─────────────────────────────────────
+
+nz_int_narrow!(N064N008, NonZeroI64, i64, NonZeroI8, i8);
+nz_int_narrow!(N064N016, NonZeroI64, i64, NonZeroI16, i16);
+nz_int_narrow!(N064N032, NonZeroI64, i64, NonZeroI32, i32);
 
 // ── Two's-complement big-endian byte encodings ────────────────────
 
@@ -57,6 +63,27 @@ crate::iso! {
     pub I064LE08 : i64 => L2<8> {
         forward: i64_to_le08,
         back:    le08_to_i64,
+    }
+}
+
+// ── Lex-key big-endian encoding (LX) ──────────────────────────────
+
+const fn i64_to_lx08(x: i64) -> LX<8> {
+    LX((x as u64).wrapping_add(0x8000_0000_0000_0000).to_be_bytes())
+}
+const fn lx08_to_i64(b: LX<8>) -> i64 {
+    u64::from_be_bytes(b.0).wrapping_sub(0x8000_0000_0000_0000) as i64
+}
+
+crate::iso! {
+    /// `i64 ↔ LX<8>` — bias-encoded big-endian iso whose raw byte
+    /// `Ord` matches signed numeric order. See [`I008LX01`] for the
+    /// design rationale.
+    ///
+    /// [`I008LX01`]: crate::core::i008::I008LX01
+    pub I064LX08 : i64 => LX<8> {
+        forward: i64_to_lx08,
+        back:    lx08_to_i64,
     }
 }
 
@@ -108,6 +135,36 @@ mod tests {
 
     // (Reference to I008I064/I016I064 is via the import above; the
     // signed-i64-source proptests for byte encodings appear next.)
+
+    // ── NonZero signed narrowing (N064N###) spot + property ───────
+
+    fn arb_nz_i8() -> impl Strategy<Value = NonZeroI8> {
+        any::<i8>().prop_filter_map("non-zero i8", NonZeroI8::new)
+    }
+    fn arb_nz_i16() -> impl Strategy<Value = NonZeroI16> {
+        any::<i16>().prop_filter_map("non-zero i16", NonZeroI16::new)
+    }
+    fn arb_nz_i32() -> impl Strategy<Value = NonZeroI32> {
+        any::<i32>().prop_filter_map("non-zero i32", NonZeroI32::new)
+    }
+    fn arb_nz_i64() -> impl Strategy<Value = NonZeroI64> {
+        any::<i64>().prop_filter_map("non-zero i64", NonZeroI64::new)
+    }
+
+    proptest! {
+        #[test]
+        fn n064n008_galois_l(a in arb_nz_i64(), b in arb_nz_i8()) {
+            prop_assert!(conn_laws::galois_l(&N064N008.conn_l(), a, b));
+        }
+        #[test]
+        fn n064n016_galois_l(a in arb_nz_i64(), b in arb_nz_i16()) {
+            prop_assert!(conn_laws::galois_l(&N064N016.conn_l(), a, b));
+        }
+        #[test]
+        fn n064n032_galois_l(a in arb_nz_i64(), b in arb_nz_i32()) {
+            prop_assert!(conn_laws::galois_l(&N064N032.conn_l(), a, b));
+        }
+    }
 
     fn arb_byte8() -> impl Strategy<Value = B2<8>> {
         prop_oneof![Just([0; 8]), Just([0xFF; 8]), any::<[u8; 8]>()].prop_map(B2)
@@ -171,6 +228,59 @@ mod tests {
         #[test]
         fn i064_l2_order_preserving(a in any::<i64>(), b in any::<i64>()) {
             prop_assert_eq!(a.cmp(&b), I064LE08.ceil(a).cmp(&I064LE08.ceil(b)));
+        }
+    }
+
+    // ── LX (lex-sortable big-endian) byte-encoding tests ──────────
+
+    fn arb_lxbyte8() -> impl Strategy<Value = LX<8>> {
+        prop_oneof![
+            Just([0; 8]),
+            Just([0x80, 0, 0, 0, 0, 0, 0, 0]),
+            Just([0xFF; 8]),
+            any::<[u8; 8]>()
+        ]
+        .prop_map(LX)
+    }
+
+    #[test]
+    fn i064lx08_boundary_bytes() {
+        assert_eq!(I064LX08.ceil(i64::MIN), LX([0x00; 8]));
+        assert_eq!(I064LX08.ceil(0_i64), LX([0x80, 0, 0, 0, 0, 0, 0, 0]));
+        assert_eq!(I064LX08.ceil(i64::MAX), LX([0xFF; 8]));
+        assert_eq!(I064LX08.upper(LX([0x00; 8])), i64::MIN);
+        assert_eq!(I064LX08.upper(LX([0x80, 0, 0, 0, 0, 0, 0, 0])), 0_i64);
+        assert_eq!(I064LX08.upper(LX([0xFF; 8])), i64::MAX);
+    }
+
+    proptest! {
+        #[test]
+        fn i064_lx_iso_roundtrip_l(
+            a in prop_oneof![Just(i64::MIN), Just(0i64), Just(i64::MAX), any::<i64>()]
+        ) {
+            prop_assert!(conn_laws::iso_roundtrip_l(&I064LX08.conn_l(), a));
+        }
+        #[test]
+        fn i064_lx_roundtrip_ceil(b in arb_lxbyte8()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&I064LX08.conn_l(), b));
+        }
+        #[test]
+        fn i064_lx_galois_l(a in any::<i64>(), b in arb_lxbyte8()) {
+            prop_assert!(conn_laws::galois_l(&I064LX08.conn_l(), a, b));
+        }
+        #[test]
+        fn i064_lx_galois_r(a in any::<i64>(), b in arb_lxbyte8()) {
+            prop_assert!(conn_laws::galois_r(&I064LX08.conn_r(), a, b));
+        }
+        #[test]
+        fn i064_lx_floor_le_ceil(a in any::<i64>()) {
+            prop_assert!(conn_laws::floor_le_ceil(&I064LX08, a));
+        }
+        #[test]
+        fn i064_lx_signed_cmp_matches_raw_byte_cmp(a in any::<i64>(), b in any::<i64>()) {
+            let ka = I064LX08.ceil(a).0;
+            let kb = I064LX08.ceil(b).0;
+            prop_assert_eq!(a.cmp(&b), ka.cmp(&kb));
         }
     }
 }

--- a/src/core/i128.rs
+++ b/src/core/i128.rs
@@ -5,9 +5,9 @@
 //! `crate::fixed::i128`.
 
 #[allow(unused_imports)]
-use crate::core::{B2, L2};
-use crate::core::{int_int_narrow, int_uint, int_uint_narrow, nz_int_ext};
-use ::core::num::NonZeroI128;
+use crate::core::{B2, L2, LX};
+use crate::core::{int_int_narrow, int_uint, int_uint_narrow, nz_int_ext, nz_int_narrow};
+use ::core::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128};
 
 // ── §1 std-int Conns sourced from `i128` ──────────────────────────
 
@@ -25,6 +25,13 @@ int_uint!(I128U128, i128, u128);
 // ── §3 i128 ↔ NonZeroI128 ─────────────────────────────────────────
 
 nz_int_ext!(I128N128, i128, NonZeroI128);
+
+// ── NonZero signed narrowings ─────────────────────────────────────
+
+nz_int_narrow!(N128N008, NonZeroI128, i128, NonZeroI8, i8);
+nz_int_narrow!(N128N016, NonZeroI128, i128, NonZeroI16, i16);
+nz_int_narrow!(N128N032, NonZeroI128, i128, NonZeroI32, i32);
+nz_int_narrow!(N128N064, NonZeroI128, i128, NonZeroI64, i64);
 
 // ── Two's-complement big-endian byte encodings ────────────────────
 
@@ -57,6 +64,29 @@ crate::iso! {
     pub I128LE16 : i128 => L2<16> {
         forward: i128_to_le16,
         back:    le16_to_i128,
+    }
+}
+
+// ── Lex-key big-endian encoding (LX) ──────────────────────────────
+
+const fn i128_to_lx16(x: i128) -> LX<16> {
+    LX((x as u128)
+        .wrapping_add(0x8000_0000_0000_0000_0000_0000_0000_0000)
+        .to_be_bytes())
+}
+const fn lx16_to_i128(b: LX<16>) -> i128 {
+    u128::from_be_bytes(b.0).wrapping_sub(0x8000_0000_0000_0000_0000_0000_0000_0000) as i128
+}
+
+crate::iso! {
+    /// `i128 ↔ LX<16>` — bias-encoded big-endian iso whose raw byte
+    /// `Ord` matches signed numeric order. See [`I008LX01`] for the
+    /// design rationale.
+    ///
+    /// [`I008LX01`]: crate::core::i008::I008LX01
+    pub I128LX16 : i128 => LX<16> {
+        forward: i128_to_lx16,
+        back:    lx16_to_i128,
     }
 }
 
@@ -97,6 +127,43 @@ mod tests {
         assert_eq!(U128I128.floor(u128::MAX), i128::MAX);
         assert_eq!(U128I128.floor(U128I128.lower(50)), 50);
         assert_eq!(U128I128.floor(U128I128.lower(i128::MAX)), i128::MAX);
+    }
+
+    // ── NonZero signed narrowing (N128N###) spot + property ──────
+
+    fn arb_nz_i8() -> impl Strategy<Value = NonZeroI8> {
+        any::<i8>().prop_filter_map("non-zero i8", NonZeroI8::new)
+    }
+    fn arb_nz_i16() -> impl Strategy<Value = NonZeroI16> {
+        any::<i16>().prop_filter_map("non-zero i16", NonZeroI16::new)
+    }
+    fn arb_nz_i32() -> impl Strategy<Value = NonZeroI32> {
+        any::<i32>().prop_filter_map("non-zero i32", NonZeroI32::new)
+    }
+    fn arb_nz_i64() -> impl Strategy<Value = NonZeroI64> {
+        any::<i64>().prop_filter_map("non-zero i64", NonZeroI64::new)
+    }
+    fn arb_nz_i128() -> impl Strategy<Value = NonZeroI128> {
+        any::<i128>().prop_filter_map("non-zero i128", NonZeroI128::new)
+    }
+
+    proptest! {
+        #[test]
+        fn n128n008_galois_l(a in arb_nz_i128(), b in arb_nz_i8()) {
+            prop_assert!(conn_laws::galois_l(&N128N008.conn_l(), a, b));
+        }
+        #[test]
+        fn n128n016_galois_l(a in arb_nz_i128(), b in arb_nz_i16()) {
+            prop_assert!(conn_laws::galois_l(&N128N016.conn_l(), a, b));
+        }
+        #[test]
+        fn n128n032_galois_l(a in arb_nz_i128(), b in arb_nz_i32()) {
+            prop_assert!(conn_laws::galois_l(&N128N032.conn_l(), a, b));
+        }
+        #[test]
+        fn n128n064_galois_l(a in arb_nz_i128(), b in arb_nz_i64()) {
+            prop_assert!(conn_laws::galois_l(&N128N064.conn_l(), a, b));
+        }
     }
 
     fn arb_byte16() -> impl Strategy<Value = B2<16>> {
@@ -156,6 +223,69 @@ mod tests {
         #[test]
         fn i128_l2_order_preserving(a in any::<i128>(), b in any::<i128>()) {
             prop_assert_eq!(a.cmp(&b), I128LE16.ceil(a).cmp(&I128LE16.ceil(b)));
+        }
+    }
+
+    // ── LX (lex-sortable big-endian) byte-encoding tests ──────────
+
+    fn arb_lxbyte16() -> impl Strategy<Value = LX<16>> {
+        let mid = {
+            let mut a = [0u8; 16];
+            a[0] = 0x80;
+            a
+        };
+        prop_oneof![
+            Just([0; 16]),
+            Just(mid),
+            Just([0xFF; 16]),
+            any::<[u8; 16]>()
+        ]
+        .prop_map(LX)
+    }
+
+    #[test]
+    fn i128lx16_boundary_bytes() {
+        let mid = {
+            let mut a = [0u8; 16];
+            a[0] = 0x80;
+            a
+        };
+        assert_eq!(I128LX16.ceil(i128::MIN), LX([0x00; 16]));
+        assert_eq!(I128LX16.ceil(0_i128), LX(mid));
+        assert_eq!(I128LX16.ceil(i128::MAX), LX([0xFF; 16]));
+        assert_eq!(I128LX16.upper(LX([0x00; 16])), i128::MIN);
+        assert_eq!(I128LX16.upper(LX(mid)), 0_i128);
+        assert_eq!(I128LX16.upper(LX([0xFF; 16])), i128::MAX);
+    }
+
+    proptest! {
+        #[test]
+        fn i128_lx_iso_roundtrip_l(
+            a in prop_oneof![Just(i128::MIN), Just(0i128), Just(i128::MAX), any::<i128>()]
+        ) {
+            prop_assert!(conn_laws::iso_roundtrip_l(&I128LX16.conn_l(), a));
+        }
+        #[test]
+        fn i128_lx_roundtrip_ceil(b in arb_lxbyte16()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&I128LX16.conn_l(), b));
+        }
+        #[test]
+        fn i128_lx_galois_l(a in any::<i128>(), b in arb_lxbyte16()) {
+            prop_assert!(conn_laws::galois_l(&I128LX16.conn_l(), a, b));
+        }
+        #[test]
+        fn i128_lx_galois_r(a in any::<i128>(), b in arb_lxbyte16()) {
+            prop_assert!(conn_laws::galois_r(&I128LX16.conn_r(), a, b));
+        }
+        #[test]
+        fn i128_lx_floor_le_ceil(a in any::<i128>()) {
+            prop_assert!(conn_laws::floor_le_ceil(&I128LX16, a));
+        }
+        #[test]
+        fn i128_lx_signed_cmp_matches_raw_byte_cmp(a in any::<i128>(), b in any::<i128>()) {
+            let ka = I128LX16.ceil(a).0;
+            let kb = I128LX16.ceil(b).0;
+            prop_assert_eq!(a.cmp(&b), ka.cmp(&kb));
         }
     }
 }

--- a/src/core/u008.rs
+++ b/src/core/u008.rs
@@ -7,8 +7,8 @@
 
 #[allow(unused_imports)]
 use crate::core::LE;
-use crate::core::{ext_int, nz_uint_ext, uint_int_sat, uint_uint};
-use ::core::num::NonZeroU8;
+use crate::core::{ext_int, nz_uint_ext, nz_uint_widen, uint_int_sat, uint_uint};
+use ::core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128};
 
 // ── §1 std-int Conns sourced from `u8` ────────────────────────────
 
@@ -26,6 +26,13 @@ uint_uint!(U008U128, u8, u128);
 // ── §3 u8 ↔ NonZeroU8 ─────────────────────────────────────────────
 
 nz_uint_ext!(U008N008, u8, NonZeroU8);
+
+// ── NonZero unsigned widenings ────────────────────────────────────
+
+nz_uint_widen!(N008N016, NonZeroU8, u8, NonZeroU16, u16);
+nz_uint_widen!(N008N032, NonZeroU8, u8, NonZeroU32, u32);
+nz_uint_widen!(N008N064, NonZeroU8, u8, NonZeroU64, u64);
+nz_uint_widen!(N008N128, NonZeroU8, u8, NonZeroU128, u128);
 
 // ── Sortable big-endian byte encodings ────────────────────────────
 
@@ -189,6 +196,65 @@ mod tests {
         #[test]
         fn u008n008_inner_then_ceil_recovers_nonzero(nz in arb_nz_u8()) {
             prop_assert_eq!(U008N008.ceil(U008N008.upper(nz)), nz);
+        }
+    }
+
+    // ── NonZero unsigned widening (N###N###) spot + property checks ─
+
+    #[test]
+    fn n008n016_widens_losslessly_at_boundary() {
+        let one = NonZeroU8::new(1).unwrap();
+        let max = NonZeroU8::new(u8::MAX).unwrap();
+        assert_eq!(N008N016.ceil(one), NonZeroU16::new(1).unwrap());
+        assert_eq!(N008N016.ceil(max), NonZeroU16::new(u8::MAX as u16).unwrap());
+    }
+
+    #[test]
+    fn n008n016_inner_saturates_above_source_max() {
+        // Any NonZeroU16 above u8::MAX saturates to NonZeroU8::MAX.
+        let big = NonZeroU16::new(u16::MAX).unwrap();
+        assert_eq!(N008N016.upper(big), NonZeroU8::new(u8::MAX).unwrap());
+        // Just-above-cap saturates too.
+        let just_above = NonZeroU16::new(u8::MAX as u16 + 1).unwrap();
+        assert_eq!(N008N016.upper(just_above), NonZeroU8::new(u8::MAX).unwrap());
+        // In-range survives.
+        let in_range = NonZeroU16::new(42).unwrap();
+        assert_eq!(N008N016.upper(in_range), NonZeroU8::new(42).unwrap());
+    }
+
+    fn arb_nz_u16() -> impl Strategy<Value = NonZeroU16> {
+        any::<u16>().prop_filter_map("non-zero u16", NonZeroU16::new)
+    }
+    fn arb_nz_u32() -> impl Strategy<Value = NonZeroU32> {
+        any::<u32>().prop_filter_map("non-zero u32", NonZeroU32::new)
+    }
+    fn arb_nz_u64() -> impl Strategy<Value = NonZeroU64> {
+        any::<u64>().prop_filter_map("non-zero u64", NonZeroU64::new)
+    }
+    fn arb_nz_u128() -> impl Strategy<Value = NonZeroU128> {
+        any::<u128>().prop_filter_map("non-zero u128", NonZeroU128::new)
+    }
+
+    proptest! {
+        #[test]
+        fn n008n016_galois_l(a in arb_nz_u8(), b in arb_nz_u16()) {
+            prop_assert!(conn_laws::galois_l(&N008N016.conn_l(), a, b));
+        }
+        #[test]
+        fn n008n016_round_trip_below_cap(n in arb_nz_u8()) {
+            prop_assert_eq!(N008N016.upper(N008N016.ceil(n)), n);
+        }
+        #[test]
+        fn n008n032_galois_l(a in arb_nz_u8(), b in arb_nz_u32()) {
+            prop_assert!(conn_laws::galois_l(&N008N032.conn_l(), a, b));
+        }
+        #[test]
+        fn n008n064_galois_l(a in arb_nz_u8(), b in arb_nz_u64()) {
+            prop_assert!(conn_laws::galois_l(&N008N064.conn_l(), a, b));
+        }
+        #[test]
+        fn n008n128_galois_l(a in arb_nz_u8(), b in arb_nz_u128()) {
+            prop_assert!(conn_laws::galois_l(&N008N128.conn_l(), a, b));
         }
     }
 

--- a/src/core/u016.rs
+++ b/src/core/u016.rs
@@ -6,8 +6,10 @@
 
 #[allow(unused_imports)]
 use crate::core::LE;
-use crate::core::{ext_int, nz_uint_ext, uint_int_sat, uint_uint, uint_uint_narrow};
-use ::core::num::NonZeroU16;
+use crate::core::{
+    ext_int, nz_uint_ext, nz_uint_narrow, nz_uint_widen, uint_int_sat, uint_uint, uint_uint_narrow,
+};
+use ::core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128};
 
 // ── §1 std-int Conns sourced from `u16` ───────────────────────────
 
@@ -25,6 +27,16 @@ uint_uint!(U016U128, u16, u128);
 // ── §3 u16 ↔ NonZeroU16 ───────────────────────────────────────────
 
 nz_uint_ext!(U016N016, u16, NonZeroU16);
+
+// ── NonZero unsigned narrowings ───────────────────────────────────
+
+nz_uint_narrow!(N016N008, NonZeroU16, u16, NonZeroU8, u8);
+
+// ── NonZero unsigned widenings ────────────────────────────────────
+
+nz_uint_widen!(N016N032, NonZeroU16, u16, NonZeroU32, u32);
+nz_uint_widen!(N016N064, NonZeroU16, u16, NonZeroU64, u64);
+nz_uint_widen!(N016N128, NonZeroU16, u16, NonZeroU128, u128);
 
 // ── Sortable big-endian byte encodings ────────────────────────────
 
@@ -124,6 +136,37 @@ mod tests {
         assert_eq!(I128U016.ceil(i128::MAX), u16::MAX);
         assert_eq!(I032U016.upper(u16::MAX), i32::MAX);
         assert_eq!(I128U016.upper(u16::MAX), i128::MAX);
+    }
+
+    // ── NonZero unsigned narrowing (N016N008) spot + property ─────
+
+    fn arb_nz_u8() -> impl Strategy<Value = NonZeroU8> {
+        any::<u8>().prop_filter_map("non-zero u8", NonZeroU8::new)
+    }
+    fn arb_nz_u16() -> impl Strategy<Value = NonZeroU16> {
+        any::<u16>().prop_filter_map("non-zero u16", NonZeroU16::new)
+    }
+
+    #[test]
+    fn n016n008_saturates_above_target_max() {
+        let big = NonZeroU16::new(u16::MAX).unwrap();
+        let just_above = NonZeroU16::new(u8::MAX as u16 + 1).unwrap();
+        let in_range = NonZeroU16::new(42).unwrap();
+        assert_eq!(N016N008.ceil(big), NonZeroU8::new(u8::MAX).unwrap());
+        assert_eq!(N016N008.ceil(just_above), NonZeroU8::new(u8::MAX).unwrap());
+        assert_eq!(N016N008.ceil(in_range), NonZeroU8::new(42).unwrap());
+        // FINE_MAX fixup: inner(NZ(u8::MAX)) = NZ(u16::MAX)
+        assert_eq!(
+            N016N008.upper(NonZeroU8::new(u8::MAX).unwrap()),
+            NonZeroU16::new(u16::MAX).unwrap()
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn n016n008_galois_l(a in arb_nz_u16(), b in arb_nz_u8()) {
+            prop_assert!(conn_laws::galois_l(&N016N008.conn_l(), a, b));
+        }
     }
 
     fn arb_byte2() -> impl Strategy<Value = [u8; 2]> {

--- a/src/core/u032.rs
+++ b/src/core/u032.rs
@@ -6,8 +6,10 @@
 
 #[allow(unused_imports)]
 use crate::core::LE;
-use crate::core::{ext_int, nz_uint_ext, uint_int_sat, uint_uint, uint_uint_narrow};
-use ::core::num::NonZeroU32;
+use crate::core::{
+    ext_int, nz_uint_ext, nz_uint_narrow, nz_uint_widen, uint_int_sat, uint_uint, uint_uint_narrow,
+};
+use ::core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128};
 
 // ── §1 std-int Conns sourced from `u32` ───────────────────────────
 
@@ -25,6 +27,16 @@ uint_uint!(U032U128, u32, u128);
 // ── §3 u32 ↔ NonZeroU32 ───────────────────────────────────────────
 
 nz_uint_ext!(U032N032, u32, NonZeroU32);
+
+// ── NonZero unsigned narrowings ───────────────────────────────────
+
+nz_uint_narrow!(N032N008, NonZeroU32, u32, NonZeroU8, u8);
+nz_uint_narrow!(N032N016, NonZeroU32, u32, NonZeroU16, u16);
+
+// ── NonZero unsigned widenings ────────────────────────────────────
+
+nz_uint_widen!(N032N064, NonZeroU32, u32, NonZeroU64, u64);
+nz_uint_widen!(N032N128, NonZeroU32, u32, NonZeroU128, u128);
 
 // ── Sortable big-endian byte encodings ────────────────────────────
 
@@ -110,6 +122,29 @@ mod tests {
         assert_eq!(I128U032.ceil(i128::MIN), 0);
         assert_eq!(I064U032.upper(u32::MAX), i64::MAX);
         assert_eq!(I128U032.upper(u32::MAX), i128::MAX);
+    }
+
+    // ── NonZero unsigned narrowing (N032N###) spot + property ─────
+
+    fn arb_nz_u8() -> impl Strategy<Value = NonZeroU8> {
+        any::<u8>().prop_filter_map("non-zero u8", NonZeroU8::new)
+    }
+    fn arb_nz_u16() -> impl Strategy<Value = NonZeroU16> {
+        any::<u16>().prop_filter_map("non-zero u16", NonZeroU16::new)
+    }
+    fn arb_nz_u32() -> impl Strategy<Value = NonZeroU32> {
+        any::<u32>().prop_filter_map("non-zero u32", NonZeroU32::new)
+    }
+
+    proptest! {
+        #[test]
+        fn n032n008_galois_l(a in arb_nz_u32(), b in arb_nz_u8()) {
+            prop_assert!(conn_laws::galois_l(&N032N008.conn_l(), a, b));
+        }
+        #[test]
+        fn n032n016_galois_l(a in arb_nz_u32(), b in arb_nz_u16()) {
+            prop_assert!(conn_laws::galois_l(&N032N016.conn_l(), a, b));
+        }
     }
 
     fn arb_byte4() -> impl Strategy<Value = [u8; 4]> {

--- a/src/core/u064.rs
+++ b/src/core/u064.rs
@@ -6,8 +6,10 @@
 
 #[allow(unused_imports)]
 use crate::core::LE;
-use crate::core::{ext_int, nz_uint_ext, uint_int_sat, uint_uint, uint_uint_narrow};
-use ::core::num::NonZeroU64;
+use crate::core::{
+    ext_int, nz_uint_ext, nz_uint_narrow, nz_uint_widen, uint_int_sat, uint_uint, uint_uint_narrow,
+};
+use ::core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128};
 
 // ── §1 std-int Conns sourced from `u64` ───────────────────────────
 
@@ -25,6 +27,16 @@ uint_uint!(U064U128, u64, u128);
 // ── §3 u64 ↔ NonZeroU64 ───────────────────────────────────────────
 
 nz_uint_ext!(U064N064, u64, NonZeroU64);
+
+// ── NonZero unsigned narrowings ───────────────────────────────────
+
+nz_uint_narrow!(N064N008, NonZeroU64, u64, NonZeroU8, u8);
+nz_uint_narrow!(N064N016, NonZeroU64, u64, NonZeroU16, u16);
+nz_uint_narrow!(N064N032, NonZeroU64, u64, NonZeroU32, u32);
+
+// ── NonZero unsigned widenings ────────────────────────────────────
+
+nz_uint_widen!(N064N128, NonZeroU64, u64, NonZeroU128, u128);
 
 // ── Sortable big-endian byte encodings ────────────────────────────
 
@@ -101,6 +113,36 @@ mod tests {
         assert_eq!(I128U064.ceil(i128::MIN), 0);
         assert_eq!(I128U064.ceil(i128::MAX), u64::MAX);
         assert_eq!(I128U064.upper(u64::MAX), i128::MAX);
+    }
+
+    // ── NonZero unsigned narrowing (N064N###) spot + property ─────
+
+    fn arb_nz_u8() -> impl Strategy<Value = NonZeroU8> {
+        any::<u8>().prop_filter_map("non-zero u8", NonZeroU8::new)
+    }
+    fn arb_nz_u16() -> impl Strategy<Value = NonZeroU16> {
+        any::<u16>().prop_filter_map("non-zero u16", NonZeroU16::new)
+    }
+    fn arb_nz_u32() -> impl Strategy<Value = NonZeroU32> {
+        any::<u32>().prop_filter_map("non-zero u32", NonZeroU32::new)
+    }
+    fn arb_nz_u64() -> impl Strategy<Value = NonZeroU64> {
+        any::<u64>().prop_filter_map("non-zero u64", NonZeroU64::new)
+    }
+
+    proptest! {
+        #[test]
+        fn n064n008_galois_l(a in arb_nz_u64(), b in arb_nz_u8()) {
+            prop_assert!(conn_laws::galois_l(&N064N008.conn_l(), a, b));
+        }
+        #[test]
+        fn n064n016_galois_l(a in arb_nz_u64(), b in arb_nz_u16()) {
+            prop_assert!(conn_laws::galois_l(&N064N016.conn_l(), a, b));
+        }
+        #[test]
+        fn n064n032_galois_l(a in arb_nz_u64(), b in arb_nz_u32()) {
+            prop_assert!(conn_laws::galois_l(&N064N032.conn_l(), a, b));
+        }
     }
 
     fn arb_byte8() -> impl Strategy<Value = [u8; 8]> {

--- a/src/core/u128.rs
+++ b/src/core/u128.rs
@@ -6,8 +6,8 @@
 
 #[allow(unused_imports)]
 use crate::core::LE;
-use crate::core::{nz_uint_ext, uint_int_sat, uint_uint_narrow};
-use ::core::num::NonZeroU128;
+use crate::core::{nz_uint_ext, nz_uint_narrow, uint_int_sat, uint_uint_narrow};
+use ::core::num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128};
 
 // ── §1 std-int Conns sourced from `u128` ──────────────────────────
 
@@ -25,6 +25,13 @@ uint_uint_narrow!(U128U064, u128, u64);
 // ── §3 u128 ↔ NonZeroU128 ─────────────────────────────────────────
 
 nz_uint_ext!(U128N128, u128, NonZeroU128);
+
+// ── NonZero unsigned narrowings ───────────────────────────────────
+
+nz_uint_narrow!(N128N008, NonZeroU128, u128, NonZeroU8, u8);
+nz_uint_narrow!(N128N016, NonZeroU128, u128, NonZeroU16, u16);
+nz_uint_narrow!(N128N032, NonZeroU128, u128, NonZeroU32, u32);
+nz_uint_narrow!(N128N064, NonZeroU128, u128, NonZeroU64, u64);
 
 // ── Sortable big-endian byte encodings ────────────────────────────
 
@@ -87,6 +94,43 @@ mod tests {
         assert_eq!(I128U128.ceil(i128::MIN), 0);
         assert_eq!(I128U128.ceil(i128::MAX), i128::MAX as u128);
         assert_eq!(I128U128.upper(u128::MAX), i128::MAX);
+    }
+
+    // ── NonZero unsigned narrowing (N128N###) spot + property ─────
+
+    fn arb_nz_u8() -> impl Strategy<Value = NonZeroU8> {
+        any::<u8>().prop_filter_map("non-zero u8", NonZeroU8::new)
+    }
+    fn arb_nz_u16() -> impl Strategy<Value = NonZeroU16> {
+        any::<u16>().prop_filter_map("non-zero u16", NonZeroU16::new)
+    }
+    fn arb_nz_u32() -> impl Strategy<Value = NonZeroU32> {
+        any::<u32>().prop_filter_map("non-zero u32", NonZeroU32::new)
+    }
+    fn arb_nz_u64() -> impl Strategy<Value = NonZeroU64> {
+        any::<u64>().prop_filter_map("non-zero u64", NonZeroU64::new)
+    }
+    fn arb_nz_u128() -> impl Strategy<Value = NonZeroU128> {
+        any::<u128>().prop_filter_map("non-zero u128", NonZeroU128::new)
+    }
+
+    proptest! {
+        #[test]
+        fn n128n008_galois_l(a in arb_nz_u128(), b in arb_nz_u8()) {
+            prop_assert!(conn_laws::galois_l(&N128N008.conn_l(), a, b));
+        }
+        #[test]
+        fn n128n016_galois_l(a in arb_nz_u128(), b in arb_nz_u16()) {
+            prop_assert!(conn_laws::galois_l(&N128N016.conn_l(), a, b));
+        }
+        #[test]
+        fn n128n032_galois_l(a in arb_nz_u128(), b in arb_nz_u32()) {
+            prop_assert!(conn_laws::galois_l(&N128N032.conn_l(), a, b));
+        }
+        #[test]
+        fn n128n064_galois_l(a in arb_nz_u128(), b in arb_nz_u64()) {
+            prop_assert!(conn_laws::galois_l(&N128N064.conn_l(), a, b));
+        }
     }
 
     fn arb_byte16() -> impl Strategy<Value = [u8; 16]> {

--- a/src/fixed.rs
+++ b/src/fixed.rs
@@ -62,22 +62,14 @@
 //! `core`/`fixed` split.
 //!
 //! The std-int Conn macros (`ext_int!`, `int_uint!`, `nz_int_ext!`,
-//! …) used to live here; after Plan 26 they live in [`crate::core`].
-//! For backward-compat the per-primitive submodules below import them
-//! via `use crate::core::{…}` (and this module re-exports them under
-//! their original names so `use super::{…}` from this module's
-//! children continues to compile during the migration).
+//! …) live in [`crate::core`]; per-host-type submodules import them
+//! via `use crate::core::{…}` directly.
 //!
 //! The `fixed`-crate `FixedI<N><F>` / `FixedU<N><F>` types already
 //! derive `PartialEq` / `Eq` / `PartialOrd` / `Ord` upstream —
 //! totally ordered by their underlying integer bits — so they flow
 //! through any `T: Eq + PartialOrd` law predicate without per-crate
 //! impls.
-
-// `LE<N>` and the std-int Conn macros moved to `src/core.rs` in
-// Plan 26. The submodules below now import what they need directly
-// from `crate::core::*`; this module no longer needs to re-export
-// them.
 
 // ── Float → Q-format Conn macros ───────────────────────────────────
 //

--- a/src/float.rs
+++ b/src/float.rs
@@ -641,6 +641,11 @@ impl From<u32> for ExtendedFloat<f64> {
     }
 }
 
+/// IEEE binary16 wrapped under the N5 lattice.
+#[cfg(feature = "f16")]
+#[cfg_attr(docsrs, doc(cfg(feature = "f16")))]
+pub type F016 = ExtendedFloat<f16>;
+
 /// IEEE binary32 wrapped under the N5 lattice.
 pub type F032 = ExtendedFloat<f32>;
 

--- a/src/hifi.rs
+++ b/src/hifi.rs
@@ -56,7 +56,7 @@
 //! | `NANO` | `i128` total nanoseconds (vs `time/`'s i64 — hifitime is wider) |
 //! | `SECS` | `i64` whole seconds                                        |
 //! | `U008` | `u8` rung                                                  |
-//! | `N008` | `NonZeroU8` rung (canonical `N***` form per `crate::fixed::i008::I008N008`) |
+//! | `N008` | `NonZeroU8` rung (canonical `N***` form per `crate::core::i008::I008N008`) |
 //! | `F064` | [`F064`](crate::float::F064)                               |
 //! | `F032` | [`F032`](crate::float::F032)                               |
 //!

--- a/src/hifi/calendar.rs
+++ b/src/hifi/calendar.rs
@@ -35,7 +35,7 @@
 //! → u8` target code (`A123` shape, `U` = unsigned int + 8-bit
 //! width). `N008` is the matching canonical form for the
 //! `NonZeroU8` target (`A123` shape, `N` = `NonZero<*>` + 8-bit
-//! width), parallel to `crate::fixed::i008::I008N008`.
+//! width), parallel to `crate::core::i008::I008N008`.
 
 use crate::extended::Extended;
 use ::core::num::NonZeroU8;
@@ -268,7 +268,7 @@ mod tests {
     // across both calendar Conns. A new Conn family with a different
     // canonical integer range should NOT reuse this — define its own
     // boundary-biased helper rather than inheriting MONT/WKDY-specific
-    // values. (MR !69 round-1.)
+    // values.
     fn arb_u8_calendar() -> impl Strategy<Value = u8> {
         prop_oneof![
             1 => Just(0_u8),
@@ -382,8 +382,7 @@ mod tests {
         // recover `Finite(January)`, NOT `NegInf`. The collapse on
         // `ceil` is one-way; a refactor that inverted the inner arm
         // (`inner(1) → NegInf`) would silently break the round-trip
-        // round-trip while still satisfying monotonicity. (MR !69
-        // round-1.)
+        // round-trip while still satisfying monotonicity.
         let one = NonZeroU8::new(1).unwrap();
         assert_eq!(MONTN008.upper(one), Extended::Finite(MonthName::January),);
     }

--- a/src/hifi/duration.rs
+++ b/src/hifi/duration.rs
@@ -71,14 +71,14 @@ fn hd_min_secs() -> i64 {
     // exact-integer range (`2⁵³ ≈ 9 × 10¹⁵`) — losing ones of seconds
     // of precision and producing an off-by-one boundary value. The
     // `roundtrip_ceil` proptest at the boundary catches this; the
-    // integer path avoids it entirely. (Spotted in MR !63 review.)
+    // integer path avoids it entirely.
     //
     // `total_nanoseconds()` for `HD::MIN` / `HD::MAX` is an **exact
     // multiple of 10⁹** (each `NANOSECONDS_PER_CENTURY` is 100 × 365.25
     // × 86400 × 10⁹ = 3 155 760 000 × 10⁹ ns, divisible by 10⁹), so
     // truncation-vs-floor doesn't matter at the boundary —
     // `hd_min_max_total_ns_divisible_by_billion` (test below) guards
-    // this invariant. (MR !63 round-4 follow-up.)
+    // this invariant.
     (HD::MIN.total_nanoseconds() / 1_000_000_000) as i64
 }
 
@@ -182,7 +182,7 @@ fn hdursecs_ceil(d: Extended<HD>) -> i64 {
             // `[0, 10⁹)`, matching how we then "round up" sub-second
             // tails toward +∞ (i.e., this is ceiling division —
             // `s_floor + 1` is *toward* zero for negatives, *away*
-            // from zero for positives). (MR !63 round-5.)
+            // from zero for positives).
             let one_billion: i128 = 1_000_000_000;
             let s_floor: i64 = total_ns.div_euclid(one_billion) as i64;
             let sub: i128 = total_ns.rem_euclid(one_billion);
@@ -348,7 +348,7 @@ fn f064hdur_ceil(x: F064) -> Extended<HD> {
     // boundary rounding error. `hd_{min,max}_secs() as f64` casts an
     // i64 already at `±10¹⁴` (well inside f64-exact-int range) so the
     // cast is precise. Same fix shape as the round-2 migration of
-    // `hd_{min,max}_secs` for `HDURSECS`. (MR !63 round-3 review.)
+    // `hd_{min,max}_secs` for `HDURSECS`.
     let max_secs = hd_max_secs() as f64;
     let min_secs = hd_min_secs() as f64;
     if v > max_secs {
@@ -437,7 +437,7 @@ fn f032hdur_ceil(x: F032) -> Extended<HD> {
     // commentary. The trailing `as f32` cast is lossy on its own (f32
     // ULP at `±10¹⁴` is much wider than the i64 unit), but starting
     // from the integer-correct `hd_{min,max}_secs()` rules out the
-    // additive boundary error from the f64 detour. (MR !63 round-3.)
+    // additive boundary error from the f64 detour.
     let max_secs = hd_max_secs() as f32;
     let min_secs = hd_min_secs() as f32;
     if v > max_secs {
@@ -555,7 +555,7 @@ mod tests {
     // hifitime ever introduced a non-second-aligned MIN / MAX, the
     // i128-truncation `total_nanoseconds() / 1_000_000_000` would silently
     // disagree with floor-division and the `roundtrip_ceil` boundary
-    // would slip by one second. (MR !63 round-4 follow-up.)
+    // would slip by one second.
     #[test]
     fn hd_min_max_total_ns_divisible_by_billion() {
         assert_eq!(HD::MIN.total_nanoseconds() % 1_000_000_000, 0);
@@ -671,7 +671,7 @@ mod tests {
     fn hdursecs_synthetic_arms() {
         // Use the same integer-arithmetic derivation as `hd_max_secs`
         // — `HD::MAX.to_seconds() as i64` is the lossy f64-cast path
-        // the helper was migrated off of (MR !63 round 1).
+        // the helper was migrated off of.
         let max_s = (HD::MAX.total_nanoseconds() / 1_000_000_000) as i64;
         assert_eq!(HDURSECS.ceil(Extended::NegInf), i64::MIN);
         assert_eq!(HDURSECS.ceil(Extended::PosInf), max_s + 1);
@@ -681,9 +681,9 @@ mod tests {
 
     // Boundary spot check: `inner` flips to NegInf/PosInf at exactly
     // `min_s - 1` / `max_s + 1`, which is also exactly where `galois_l`
-    // is most likely to fail. (MR !63 round-3 follow-up — these can't
-    // live in `arb_hifi_total_secs_in_range` because that strategy
-    // feeds `roundtrip_ceil`, which would fail at saturation values.)
+    // is most likely to fail. These can't live in
+    // `arb_hifi_total_secs_in_range` because that strategy feeds
+    // `roundtrip_ceil`, which would fail at saturation values.
     #[test]
     fn hdursecs_inner_saturation_boundary() {
         let min_s = (HD::MIN.total_nanoseconds() / 1_000_000_000) as i64;
@@ -816,7 +816,7 @@ mod tests {
     // Uses the same integer-derived bound as the implementation
     // (`hd_min_secs() as f64`) — `HD::MIN.to_seconds()` would f64-cast
     // a `±10²³`-magnitude value past the exact-integer range and could
-    // disagree with the implementation's threshold. (MR !63 round-3.)
+    // disagree with the implementation's threshold.
     #[test]
     fn f64_hdur_ceil_min_secs_fast_path() {
         let v_min = ExtendedFloat::Extend(hd_min_secs() as f64);

--- a/src/hifi/epoch.rs
+++ b/src/hifi/epoch.rs
@@ -98,7 +98,7 @@ fn unix_max_nanos() -> i128 {
 // (`2⁵³ ≈ 9 × 10¹⁵`) — and produces an off-by-(seconds) boundary
 // value. Doing the integer division **first** lands the result
 // at `±10¹⁴`, well inside the exact-integer range, so the trailing
-// `as f64` cast is exact. (MR !64 round-2 review.)
+// `as f64` cast is exact.
 
 #[inline]
 fn hd_min_secs_f64() -> f64 {
@@ -122,7 +122,7 @@ fn hd_max_secs_f64() -> f64 {
 // that threshold has `Finite(HD::MIN_TAI epoch)` as its Galois-L
 // adjoint (the smallest Finite b satisfying v ≤ inner(b)). The walk
 // would converge to the same answer; the fast-path just skips the
-// 10¹² descend steps. (MR !64 rounds 3-4 review discussion.)
+// 10¹² descend steps.
 
 #[inline]
 fn unix_min_secs_f64() -> f64 {
@@ -301,7 +301,7 @@ fn f064etai_ceil(x: F064) -> Extended<Epoch> {
     // see helpers); going through `HD::MAX.to_seconds()` directly
     // would f64-cast a `±10²³`-magnitude value past the exact-
     // integer range and could miss out-of-range inputs by the
-    // boundary rounding error. (MR !64 round-2 review.)
+    // boundary rounding error.
     let max_secs = hd_max_secs_f64();
     let min_secs = hd_min_secs_f64();
     if v > max_secs {
@@ -577,7 +577,6 @@ fn f064eunx_ceil(x: F064) -> Extended<Epoch> {
     // `epoch_to_unix_f64(Epoch::from_tai_duration(HD::MAX))` would
     // f64-cast through `to_unix_seconds` at `±10²³` magnitude past
     // f64's exact-integer range and could miss out-of-range inputs.
-    // (MR !64 round-2 review.)
     let unix_max_secs = unix_max_secs_f64();
     let unix_min_secs = unix_min_secs_f64();
     if v > unix_max_secs {
@@ -717,9 +716,9 @@ fn bdt_max_nanos() -> i128 {
 }
 
 // Per-scale f64 second bounds via integer division (`nanos / 10⁹`,
-// landing at ~10¹⁴ — exact in f64). The MR !64 round-2 lesson:
-// going through `to_seconds()` directly f64-casts a value past
-// `2⁵³`, off-by-seconds at the boundary.
+// landing at ~10¹⁴ — exact in f64). Going through `to_seconds()`
+// directly f64-casts a value past `2⁵³`, off-by-seconds at the
+// boundary.
 
 #[inline]
 fn gpst_min_secs_f64() -> f64 {
@@ -2015,8 +2014,7 @@ mod tests {
         // would take ~10¹² steps; the `<=` boundary check fast-paths
         // to MIN. Uses `hd_min_secs_f64()` (matches the implementation's
         // threshold) rather than `HD::MIN.to_seconds()` whose `±10²³`-
-        // magnitude f64 cast could disagree by ULPs. (MR !63 round-3
-        // shape, carried into MR !64.)
+        // magnitude f64 cast could disagree by ULPs.
         let v_min = ExtendedFloat::Extend(hd_min_secs_f64());
         assert_eq!(
             F064ETAI.ceil(v_min),
@@ -2027,7 +2025,7 @@ mod tests {
     // Pins the asymmetric-name vs equal-value relationship between
     // `unix_min_secs_f64` and `hd_min_secs_f64`. Documented at length
     // above their definitions; the test makes the equality machine-
-    // checked so it can't drift silently. (MR !64 round-5 follow-up.)
+    // checked so it can't drift silently.
     #[test]
     fn unix_min_secs_f64_equals_hd_min_secs_f64() {
         assert_eq!(unix_min_secs_f64(), hd_min_secs_f64());
@@ -2040,7 +2038,6 @@ mod tests {
     // collapses to `hd_min_secs_f64` via UTC subtraction underflow.
     // The walk converges to `Finite(HD::MIN_TAI epoch)`. Guards
     // against regressions of the round-3/4 fast-path discussion.
-    // (MR !64 round-5 follow-up.)
     #[test]
     fn f064eunx_below_hd_min_secs_collapses_to_hd_min() {
         let v = ExtendedFloat::Extend(hd_min_secs_f64() - 1.0);
@@ -2349,7 +2346,7 @@ mod tests {
         // <https://gssc.esa.int/navipedia/index.php/Time_References_in_GNSS#GPS_Time_.28GPST.29>)
         // rather than `hifitime::SECONDS_GPS_TAI_OFFSET`, so the
         // assertion remains independent of the constant the Conn
-        // itself transitively depends on. (MR !66 round-1.)
+        // itself transitively depends on.
         let e = Epoch::from_tai_seconds(3_000_000_000.0); // ~rough 1995 TAI
         let gpst_secs = EGPSHDUR.ceil(e).to_seconds();
         let expected = e.to_tai_seconds() - 2_524_953_619.0;

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -65,7 +65,7 @@ use core::cmp::Ordering;
 /// let nan = f64::NAN;
 /// assert_eq!(Interval::new(nan, nan), Interval::<f64>::Empty);
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub enum Interval<A> {
     /// The empty interval, containing nothing.
     #[default]

--- a/src/kani/ext_int.rs
+++ b/src/kani/ext_int.rs
@@ -68,34 +68,48 @@ macro_rules! prove_ext_int {
     };
 }
 
-// ── i16 destinations ────────────────────────────────────────────────
-use crate::fixed::i016 as fi016;
-prove_ext_int!(i008i016, fi016::I008I016, i8, i16);
-prove_ext_int!(u008i016, fi016::U008I016, u8, i16);
+// Per AGENTS.md `## Conn placement`, ext_int!-generated `I###I###` /
+// `U###I###` widening Conns live in their source module — tie-break
+// rule (2). The harnesses below import per-source so the path matches
+// the actual hosting after the Plan-26 `core/`/`fixed/` split.
 
-// ── i32 destinations ────────────────────────────────────────────────
-use crate::fixed::i032 as fi032;
-prove_ext_int!(i008i032, fi032::I008I032, i8, i32);
-prove_ext_int!(i016i032, fi032::I016I032, i16, i32);
-prove_ext_int!(u008i032, fi032::U008I032, u8, i32);
-prove_ext_int!(u016i032, fi032::U016I032, u16, i32);
+use crate::core::i008 as ci008;
+use crate::core::i016 as ci016;
+use crate::core::i032 as ci032;
+use crate::core::i064 as ci064;
+use crate::core::u008 as cu008;
+use crate::core::u016 as cu016;
+use crate::core::u032 as cu032;
+use crate::core::u064 as cu064;
 
-// ── i64 destinations ────────────────────────────────────────────────
-use crate::fixed::i064 as fi064;
-prove_ext_int!(i008i064, fi064::I008I064, i8, i64);
-prove_ext_int!(i016i064, fi064::I016I064, i16, i64);
-prove_ext_int!(i032i064, fi064::I032I064, i32, i64);
-prove_ext_int!(u008i064, fi064::U008I064, u8, i64);
-prove_ext_int!(u016i064, fi064::U016I064, u16, i64);
-prove_ext_int!(u032i064, fi064::U032I064, u32, i64);
+// ── Signed widenings (I###I###, source-keyed) ───────────────────────
 
-// ── i128 destinations ───────────────────────────────────────────────
-use crate::fixed::i128 as fi128;
-prove_ext_int!(i008i128, fi128::I008I128, i8, i128);
-prove_ext_int!(i016i128, fi128::I016I128, i16, i128);
-prove_ext_int!(i032i128, fi128::I032I128, i32, i128);
-prove_ext_int!(i064i128, fi128::I064I128, i64, i128);
-prove_ext_int!(u008i128, fi128::U008I128, u8, i128);
-prove_ext_int!(u016i128, fi128::U016I128, u16, i128);
-prove_ext_int!(u032i128, fi128::U032I128, u32, i128);
-prove_ext_int!(u064i128, fi128::U064I128, u64, i128);
+prove_ext_int!(i008i016, ci008::I008I016, i8, i16);
+prove_ext_int!(i008i032, ci008::I008I032, i8, i32);
+prove_ext_int!(i008i064, ci008::I008I064, i8, i64);
+prove_ext_int!(i008i128, ci008::I008I128, i8, i128);
+
+prove_ext_int!(i016i032, ci016::I016I032, i16, i32);
+prove_ext_int!(i016i064, ci016::I016I064, i16, i64);
+prove_ext_int!(i016i128, ci016::I016I128, i16, i128);
+
+prove_ext_int!(i032i064, ci032::I032I064, i32, i64);
+prove_ext_int!(i032i128, ci032::I032I128, i32, i128);
+
+prove_ext_int!(i064i128, ci064::I064I128, i64, i128);
+
+// ── Cross-sign widenings (U###I###, source-keyed) ───────────────────
+
+prove_ext_int!(u008i016, cu008::U008I016, u8, i16);
+prove_ext_int!(u008i032, cu008::U008I032, u8, i32);
+prove_ext_int!(u008i064, cu008::U008I064, u8, i64);
+prove_ext_int!(u008i128, cu008::U008I128, u8, i128);
+
+prove_ext_int!(u016i032, cu016::U016I032, u16, i32);
+prove_ext_int!(u016i064, cu016::U016I064, u16, i64);
+prove_ext_int!(u016i128, cu016::U016I128, u16, i128);
+
+prove_ext_int!(u032i064, cu032::U032I064, u32, i64);
+prove_ext_int!(u032i128, cu032::U032I128, u32, i128);
+
+prove_ext_int!(u064i128, cu064::U064I128, u64, i128);

--- a/src/kani/int_narrow.rs
+++ b/src/kani/int_narrow.rs
@@ -70,28 +70,26 @@ macro_rules! prove_int_narrow {
     };
 }
 
-// ── i8 destinations ─────────────────────────────────────────────────
-use crate::fixed::i008 as fi008;
+// Per AGENTS.md `## Conn placement`, I###I### narrowing Conns live in
+// the source (wider) module — tie-break rule (2). The harnesses below
+// import per-source so the path matches the actual hosting after the
+// Plan-26 `core/`/`fixed/` split.
 
-prove_int_narrow!(i016i008, fi008::I016I008, i16, i8);
-prove_int_narrow!(i032i008, fi008::I032I008, i32, i8);
-prove_int_narrow!(i064i008, fi008::I064I008, i64, i8);
-prove_int_narrow!(i128i008, fi008::I128I008, i128, i8);
+use crate::core::i016 as ci016;
+use crate::core::i032 as ci032;
+use crate::core::i064 as ci064;
+use crate::core::i128 as ci128;
 
-// ── i16 destinations ────────────────────────────────────────────────
-use crate::fixed::i016 as fi016;
+prove_int_narrow!(i016i008, ci016::I016I008, i16, i8);
 
-prove_int_narrow!(i032i016, fi016::I032I016, i32, i16);
-prove_int_narrow!(i064i016, fi016::I064I016, i64, i16);
-prove_int_narrow!(i128i016, fi016::I128I016, i128, i16);
+prove_int_narrow!(i032i008, ci032::I032I008, i32, i8);
+prove_int_narrow!(i032i016, ci032::I032I016, i32, i16);
 
-// ── i32 destinations ────────────────────────────────────────────────
-use crate::fixed::i032 as fi032;
+prove_int_narrow!(i064i008, ci064::I064I008, i64, i8);
+prove_int_narrow!(i064i016, ci064::I064I016, i64, i16);
+prove_int_narrow!(i064i032, ci064::I064I032, i64, i32);
 
-prove_int_narrow!(i064i032, fi032::I064I032, i64, i32);
-prove_int_narrow!(i128i032, fi032::I128I032, i128, i32);
-
-// ── i64 destination ────────────────────────────────────────────────
-use crate::fixed::i064 as fi064;
-
-prove_int_narrow!(i128i064, fi064::I128I064, i128, i64);
+prove_int_narrow!(i128i008, ci128::I128I008, i128, i8);
+prove_int_narrow!(i128i016, ci128::I128I016, i128, i16);
+prove_int_narrow!(i128i032, ci128::I128I032, i128, i32);
+prove_int_narrow!(i128i064, ci128::I128I064, i128, i64);

--- a/src/kani/nz_ext.rs
+++ b/src/kani/nz_ext.rs
@@ -128,27 +128,27 @@ macro_rules! prove_nz_unsigned {
 }
 
 // ── Signed: full triples ────────────────────────────────────────────
-use crate::fixed::i008 as fi008;
-use crate::fixed::i016 as fi016;
-use crate::fixed::i032 as fi032;
-use crate::fixed::i064 as fi064;
-use crate::fixed::i128 as fi128;
+use crate::core::i008 as ci008;
+use crate::core::i016 as ci016;
+use crate::core::i032 as ci032;
+use crate::core::i064 as ci064;
+use crate::core::i128 as ci128;
 
-prove_nz_signed!(i008n008, fi008::I008N008, i8, NonZeroI8);
-prove_nz_signed!(i016n016, fi016::I016N016, i16, NonZeroI16);
-prove_nz_signed!(i032n032, fi032::I032N032, i32, NonZeroI32);
-prove_nz_signed!(i064n064, fi064::I064N064, i64, NonZeroI64);
-prove_nz_signed!(i128n128, fi128::I128N128, i128, NonZeroI128);
+prove_nz_signed!(i008n008, ci008::I008N008, i8, NonZeroI8);
+prove_nz_signed!(i016n016, ci016::I016N016, i16, NonZeroI16);
+prove_nz_signed!(i032n032, ci032::I032N032, i32, NonZeroI32);
+prove_nz_signed!(i064n064, ci064::I064N064, i64, NonZeroI64);
+prove_nz_signed!(i128n128, ci128::I128N128, i128, NonZeroI128);
 
 // ── Unsigned: L-Galois only ─────────────────────────────────────────
-use crate::fixed::u008 as fu008;
-use crate::fixed::u016 as fu016;
-use crate::fixed::u032 as fu032;
-use crate::fixed::u064 as fu064;
-use crate::fixed::u128 as fu128;
+use crate::core::u008 as cu008;
+use crate::core::u016 as cu016;
+use crate::core::u032 as cu032;
+use crate::core::u064 as cu064;
+use crate::core::u128 as cu128;
 
-prove_nz_unsigned!(u008n008, fu008::U008N008, u8, NonZeroU8);
-prove_nz_unsigned!(u016n016, fu016::U016N016, u16, NonZeroU16);
-prove_nz_unsigned!(u032n032, fu032::U032N032, u32, NonZeroU32);
-prove_nz_unsigned!(u064n064, fu064::U064N064, u64, NonZeroU64);
-prove_nz_unsigned!(u128n128, fu128::U128N128, u128, NonZeroU128);
+prove_nz_unsigned!(u008n008, cu008::U008N008, u8, NonZeroU8);
+prove_nz_unsigned!(u016n016, cu016::U016N016, u16, NonZeroU16);
+prove_nz_unsigned!(u032n032, cu032::U032N032, u32, NonZeroU32);
+prove_nz_unsigned!(u064n064, cu064::U064N064, u64, NonZeroU64);
+prove_nz_unsigned!(u128n128, cu128::U128N128, u128, NonZeroU128);

--- a/src/kani/uint_narrow.rs
+++ b/src/kani/uint_narrow.rs
@@ -52,31 +52,48 @@ macro_rules! prove_uint_narrow {
     };
 }
 
-// ── uint_uint_narrow! ───────────────────────────────────────────────
-use crate::fixed::u008 as fu008;
-use crate::fixed::u016 as fu016;
-use crate::fixed::u032 as fu032;
-use crate::fixed::u064 as fu064;
+// Per AGENTS.md `## Conn placement`, U###U### narrowing and I###U###
+// narrowing Conns both live in their source (wider) module — tie-break
+// rule (2). The harnesses below import per-source so the path matches
+// the actual hosting after the Plan-26 `core/`/`fixed/` split.
 
-prove_uint_narrow!(uun_u016u008, fu008::U016U008, u16, u8);
-prove_uint_narrow!(uun_u032u008, fu008::U032U008, u32, u8);
-prove_uint_narrow!(uun_u064u008, fu008::U064U008, u64, u8);
-prove_uint_narrow!(uun_u128u008, fu008::U128U008, u128, u8);
-prove_uint_narrow!(uun_u032u016, fu016::U032U016, u32, u16);
-prove_uint_narrow!(uun_u064u016, fu016::U064U016, u64, u16);
-prove_uint_narrow!(uun_u128u016, fu016::U128U016, u128, u16);
-prove_uint_narrow!(uun_u064u032, fu032::U064U032, u64, u32);
-prove_uint_narrow!(uun_u128u032, fu032::U128U032, u128, u32);
-prove_uint_narrow!(uun_u128u064, fu064::U128U064, u128, u64);
+use crate::core::i016 as ci016;
+use crate::core::i032 as ci032;
+use crate::core::i064 as ci064;
+use crate::core::i128 as ci128;
+use crate::core::u016 as cu016;
+use crate::core::u032 as cu032;
+use crate::core::u064 as cu064;
+use crate::core::u128 as cu128;
 
-// ── int_uint_narrow! ────────────────────────────────────────────────
-prove_uint_narrow!(iun_i016u008, fu008::I016U008, i16, u8);
-prove_uint_narrow!(iun_i032u008, fu008::I032U008, i32, u8);
-prove_uint_narrow!(iun_i064u008, fu008::I064U008, i64, u8);
-prove_uint_narrow!(iun_i128u008, fu008::I128U008, i128, u8);
-prove_uint_narrow!(iun_i032u016, fu016::I032U016, i32, u16);
-prove_uint_narrow!(iun_i064u016, fu016::I064U016, i64, u16);
-prove_uint_narrow!(iun_i128u016, fu016::I128U016, i128, u16);
-prove_uint_narrow!(iun_i064u032, fu032::I064U032, i64, u32);
-prove_uint_narrow!(iun_i128u032, fu032::I128U032, i128, u32);
-prove_uint_narrow!(iun_i128u064, fu064::I128U064, i128, u64);
+// ── uint_uint_narrow! (source-keyed) ────────────────────────────────
+
+prove_uint_narrow!(uun_u016u008, cu016::U016U008, u16, u8);
+
+prove_uint_narrow!(uun_u032u008, cu032::U032U008, u32, u8);
+prove_uint_narrow!(uun_u032u016, cu032::U032U016, u32, u16);
+
+prove_uint_narrow!(uun_u064u008, cu064::U064U008, u64, u8);
+prove_uint_narrow!(uun_u064u016, cu064::U064U016, u64, u16);
+prove_uint_narrow!(uun_u064u032, cu064::U064U032, u64, u32);
+
+prove_uint_narrow!(uun_u128u008, cu128::U128U008, u128, u8);
+prove_uint_narrow!(uun_u128u016, cu128::U128U016, u128, u16);
+prove_uint_narrow!(uun_u128u032, cu128::U128U032, u128, u32);
+prove_uint_narrow!(uun_u128u064, cu128::U128U064, u128, u64);
+
+// ── int_uint_narrow! (source-keyed) ─────────────────────────────────
+
+prove_uint_narrow!(iun_i016u008, ci016::I016U008, i16, u8);
+
+prove_uint_narrow!(iun_i032u008, ci032::I032U008, i32, u8);
+prove_uint_narrow!(iun_i032u016, ci032::I032U016, i32, u16);
+
+prove_uint_narrow!(iun_i064u008, ci064::I064U008, i64, u8);
+prove_uint_narrow!(iun_i064u016, ci064::I064U016, i64, u16);
+prove_uint_narrow!(iun_i064u032, ci064::I064U032, i64, u32);
+
+prove_uint_narrow!(iun_i128u008, ci128::I128U008, i128, u8);
+prove_uint_narrow!(iun_i128u016, ci128::I128U016, i128, u16);
+prove_uint_narrow!(iun_i128u032, ci128::I128U032, i128, u32);
+prove_uint_narrow!(iun_i128u064, ci128::I128U064, i128, u64);

--- a/src/kani/uint_sat.rs
+++ b/src/kani/uint_sat.rs
@@ -64,31 +64,31 @@ macro_rules! prove_uint_sat {
     };
 }
 
-// ── i8 destinations ─────────────────────────────────────────────────
-use crate::fixed::i008 as fi008;
-prove_uint_sat!(u008i008, fi008::U008I008, u8, i8);
-prove_uint_sat!(u016i008, fi008::U016I008, u16, i8);
-prove_uint_sat!(u032i008, fi008::U032I008, u32, i8);
-prove_uint_sat!(u064i008, fi008::U064I008, u64, i8);
-prove_uint_sat!(u128i008, fi008::U128I008, u128, i8);
+// Per AGENTS.md `## Conn placement`, U###I### Conns live in the source
+// (unsigned) module. The harnesses below import per-source so the path
+// matches the actual hosting after the Plan-26 `core/`/`fixed/` split.
 
-// ── i16 destinations ────────────────────────────────────────────────
-use crate::fixed::i016 as fi016;
-prove_uint_sat!(u016i016, fi016::U016I016, u16, i16);
-prove_uint_sat!(u032i016, fi016::U032I016, u32, i16);
-prove_uint_sat!(u064i016, fi016::U064I016, u64, i16);
-prove_uint_sat!(u128i016, fi016::U128I016, u128, i16);
+use crate::core::u008 as cu008;
+use crate::core::u016 as cu016;
+use crate::core::u032 as cu032;
+use crate::core::u064 as cu064;
+use crate::core::u128 as cu128;
 
-// ── i32 destinations ────────────────────────────────────────────────
-use crate::fixed::i032 as fi032;
-prove_uint_sat!(u064i032, fi032::U064I032, u64, i32);
-prove_uint_sat!(u128i032, fi032::U128I032, u128, i32);
+prove_uint_sat!(u008i008, cu008::U008I008, u8, i8);
 
-// ── i64 destinations ────────────────────────────────────────────────
-use crate::fixed::i064 as fi064;
-prove_uint_sat!(u064i064, fi064::U064I064, u64, i64);
-prove_uint_sat!(u128i064, fi064::U128I064, u128, i64);
+prove_uint_sat!(u016i008, cu016::U016I008, u16, i8);
+prove_uint_sat!(u016i016, cu016::U016I016, u16, i16);
 
-// ── i128 destinations ───────────────────────────────────────────────
-use crate::fixed::i128 as fi128;
-prove_uint_sat!(u128i128, fi128::U128I128, u128, i128);
+prove_uint_sat!(u032i008, cu032::U032I008, u32, i8);
+prove_uint_sat!(u032i016, cu032::U032I016, u32, i16);
+
+prove_uint_sat!(u064i008, cu064::U064I008, u64, i8);
+prove_uint_sat!(u064i016, cu064::U064I016, u64, i16);
+prove_uint_sat!(u064i032, cu064::U064I032, u64, i32);
+prove_uint_sat!(u064i064, cu064::U064I064, u64, i64);
+
+prove_uint_sat!(u128i008, cu128::U128I008, u128, i8);
+prove_uint_sat!(u128i016, cu128::U128I016, u128, i16);
+prove_uint_sat!(u128i032, cu128::U128I032, u128, i32);
+prove_uint_sat!(u128i064, cu128::U128I064, u128, i64);
+prove_uint_sat!(u128i128, cu128::U128I128, u128, i128);

--- a/src/kani/uint_widen.rs
+++ b/src/kani/uint_widen.rs
@@ -51,38 +51,55 @@ macro_rules! prove_uint_widen {
     };
 }
 
-// ── uint_uint! widenings ────────────────────────────────────────────
-use crate::fixed::u016 as fu016;
-use crate::fixed::u032 as fu032;
-use crate::fixed::u064 as fu064;
-use crate::fixed::u128 as fu128;
+// Per AGENTS.md `## Conn placement`, U###U### and I###U### widening
+// Conns both live in their source module — tie-break rule (2). The
+// harnesses below import per-source so the path matches the actual
+// hosting after the Plan-26 `core/`/`fixed/` split.
 
-prove_uint_widen!(uu_u008u016, fu016::U008U016, u8, u16);
-prove_uint_widen!(uu_u008u032, fu032::U008U032, u8, u32);
-prove_uint_widen!(uu_u016u032, fu032::U016U032, u16, u32);
-prove_uint_widen!(uu_u008u064, fu064::U008U064, u8, u64);
-prove_uint_widen!(uu_u016u064, fu064::U016U064, u16, u64);
-prove_uint_widen!(uu_u032u064, fu064::U032U064, u32, u64);
-prove_uint_widen!(uu_u008u128, fu128::U008U128, u8, u128);
-prove_uint_widen!(uu_u016u128, fu128::U016U128, u16, u128);
-prove_uint_widen!(uu_u032u128, fu128::U032U128, u32, u128);
-prove_uint_widen!(uu_u064u128, fu128::U064U128, u64, u128);
+use crate::core::i008 as ci008;
+use crate::core::i016 as ci016;
+use crate::core::i032 as ci032;
+use crate::core::i064 as ci064;
+use crate::core::i128 as ci128;
+use crate::core::u008 as cu008;
+use crate::core::u016 as cu016;
+use crate::core::u032 as cu032;
+use crate::core::u064 as cu064;
 
-// ── int_uint! widenings ─────────────────────────────────────────────
-use crate::fixed::u008 as fu008;
+// ── uint_uint! widenings (source-keyed) ─────────────────────────────
 
-prove_uint_widen!(iu_i008u008, fu008::I008U008, i8, u8);
-prove_uint_widen!(iu_i008u016, fu016::I008U016, i8, u16);
-prove_uint_widen!(iu_i016u016, fu016::I016U016, i16, u16);
-prove_uint_widen!(iu_i008u032, fu032::I008U032, i8, u32);
-prove_uint_widen!(iu_i016u032, fu032::I016U032, i16, u32);
-prove_uint_widen!(iu_i032u032, fu032::I032U032, i32, u32);
-prove_uint_widen!(iu_i008u064, fu064::I008U064, i8, u64);
-prove_uint_widen!(iu_i016u064, fu064::I016U064, i16, u64);
-prove_uint_widen!(iu_i032u064, fu064::I032U064, i32, u64);
-prove_uint_widen!(iu_i064u064, fu064::I064U064, i64, u64);
-prove_uint_widen!(iu_i008u128, fu128::I008U128, i8, u128);
-prove_uint_widen!(iu_i016u128, fu128::I016U128, i16, u128);
-prove_uint_widen!(iu_i032u128, fu128::I032U128, i32, u128);
-prove_uint_widen!(iu_i064u128, fu128::I064U128, i64, u128);
-prove_uint_widen!(iu_i128u128, fu128::I128U128, i128, u128);
+prove_uint_widen!(uu_u008u016, cu008::U008U016, u8, u16);
+prove_uint_widen!(uu_u008u032, cu008::U008U032, u8, u32);
+prove_uint_widen!(uu_u008u064, cu008::U008U064, u8, u64);
+prove_uint_widen!(uu_u008u128, cu008::U008U128, u8, u128);
+
+prove_uint_widen!(uu_u016u032, cu016::U016U032, u16, u32);
+prove_uint_widen!(uu_u016u064, cu016::U016U064, u16, u64);
+prove_uint_widen!(uu_u016u128, cu016::U016U128, u16, u128);
+
+prove_uint_widen!(uu_u032u064, cu032::U032U064, u32, u64);
+prove_uint_widen!(uu_u032u128, cu032::U032U128, u32, u128);
+
+prove_uint_widen!(uu_u064u128, cu064::U064U128, u64, u128);
+
+// ── int_uint! widenings (source-keyed) ──────────────────────────────
+
+prove_uint_widen!(iu_i008u008, ci008::I008U008, i8, u8);
+prove_uint_widen!(iu_i008u016, ci008::I008U016, i8, u16);
+prove_uint_widen!(iu_i008u032, ci008::I008U032, i8, u32);
+prove_uint_widen!(iu_i008u064, ci008::I008U064, i8, u64);
+prove_uint_widen!(iu_i008u128, ci008::I008U128, i8, u128);
+
+prove_uint_widen!(iu_i016u016, ci016::I016U016, i16, u16);
+prove_uint_widen!(iu_i016u032, ci016::I016U032, i16, u32);
+prove_uint_widen!(iu_i016u064, ci016::I016U064, i16, u64);
+prove_uint_widen!(iu_i016u128, ci016::I016U128, i16, u128);
+
+prove_uint_widen!(iu_i032u032, ci032::I032U032, i32, u32);
+prove_uint_widen!(iu_i032u064, ci032::I032U064, i32, u64);
+prove_uint_widen!(iu_i032u128, ci032::I032U128, i32, u128);
+
+prove_uint_widen!(iu_i064u064, ci064::I064U064, i64, u64);
+prove_uint_widen!(iu_i064u128, ci064::I064U128, i64, u128);
+
+prove_uint_widen!(iu_i128u128, ci128::I128U128, i128, u128);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! | code     | type                         | meaning              |
 //! |----------|------------------------------|----------------------|
-//! | `F016`   | `core::f016::F016` (gated)   | IEEE binary16        |
+//! | `F016`   | `float::F016` (gated)        | IEEE binary16        |
 //! | `F032`   | [`F032`](float::F032)        | IEEE binary32        |
 //! | `F064`   | [`F064`](float::F064)        | IEEE binary64        |
 //! | `F128`   | (deferred — `f128` unstable) | IEEE binary128       |
@@ -282,6 +282,10 @@ mod kani;
 /// | [`int_uint_narrow!`]  | `Conn<i_N, u_M>` narrowing (left-Galois).                                     |
 /// | [`nz_int_ext!`]       | `Conn<i_N, NonZero<i_N>>` asymmetric-at-zero adjoint (full triple).           |
 /// | [`nz_uint_ext!`]      | `Conn<u_N, NonZero<u_N>>` saturating-to-NonZero(1) (left-Galois).             |
+/// | [`nz_uint_widen!`]    | `Conn<NonZero<u_N>, NonZero<u_M>>` widening saturating-at-max (left-Galois).  |
+/// | [`nz_int_narrow!`]    | `Conn<NonZero<i_N>, NonZero<i_M>>` narrowing saturating-at-MIN/MAX (left-Galois). |
+/// | [`nz_uint_narrow!`]   | `Conn<NonZero<u_N>, NonZero<u_M>>` narrowing saturating-at-max (left-Galois). |
+/// | [`law_battery!`]      | declaration-form proptest suite for a Conn — galois / round-trip / floor_le_ceil. |
 ///
 /// [`iso!`]: crate::iso
 /// [`conn_k!`]: crate::conn_k
@@ -303,11 +307,16 @@ mod kani;
 /// [`int_uint_narrow!`]: crate::int_uint_narrow
 /// [`nz_int_ext!`]: crate::nz_int_ext
 /// [`nz_uint_ext!`]: crate::nz_uint_ext
+/// [`nz_uint_widen!`]: crate::nz_uint_widen
+/// [`nz_int_narrow!`]: crate::nz_int_narrow
+/// [`nz_uint_narrow!`]: crate::nz_uint_narrow
+/// [`law_battery!`]: crate::law_battery
 #[cfg(feature = "macros")]
 pub mod macros {
     pub use crate::{
         compose, compose_k, compose_l, compose_r, conn_k, conn_l, conn_r, ext_int, int_int_narrow,
-        int_uint, int_uint_narrow, iso, lift_k, lift_l, lift_r, nz_int_ext, nz_uint_ext,
-        uint_int_sat, uint_uint, uint_uint_narrow,
+        int_uint, int_uint_narrow, iso, law_battery, lift_k, lift_l, lift_r, nz_int_ext,
+        nz_int_narrow, nz_uint_ext, nz_uint_narrow, nz_uint_widen, uint_int_sat, uint_uint,
+        uint_uint_narrow,
     };
 }

--- a/tests/core/i008.rs
+++ b/tests/core/i008.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::i8`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::i008`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 //!
 //! No widening lands on `i8`. Population is split between left-
 //! Galois single-sided narrowing (`I??I008`, T3) and right-Galois
@@ -14,7 +14,7 @@ use connections::core::{
 use proptest::prelude::*;
 
 // `galois_lower` intentionally omitted; see
-// `tests/conn_std_u8_galois.rs`.
+// `tests/core/u008.rs`.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {
         mod $mod_name {

--- a/tests/core/i016.rs
+++ b/tests/core/i016.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::i16`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::i016`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 //!
 //! Existing widening Conns use the Extended-source full-triple
 //! battery. T3 (I→I narrowing) and T5 (U→I non-widening) commits
@@ -84,7 +84,7 @@ ext_int_props!(u008i016, U008I016, arb_ext_u8(), any::<i16>());
 
 // §1 I→I narrowing — single-sided left-Galois.
 // `galois_lower` intentionally omitted; see
-// `tests/conn_std_u8_galois.rs`.
+// `tests/core/u008.rs`.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {
         mod $mod_name {

--- a/tests/core/i032.rs
+++ b/tests/core/i032.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::i32`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::i032`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};
@@ -76,7 +76,7 @@ ext_int_props!(u016i032, U016I032, arb_ext_u16(), any::<i32>());
 
 // §1 I→I narrowing — single-sided left-Galois.
 // `galois_lower` intentionally omitted; see
-// `tests/conn_std_u8_galois.rs`.
+// `tests/core/u008.rs`.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {
         mod $mod_name {

--- a/tests/core/i064.rs
+++ b/tests/core/i064.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::i64`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::i064`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};
@@ -80,7 +80,7 @@ ext_int_props!(u032i064, U032I064, arb_ext_u32(), any::<i64>());
 
 // §1 I→I narrowing — single-sided left-Galois.
 // `galois_lower` intentionally omitted; see
-// `tests/conn_std_u8_galois.rs`.
+// `tests/core/u008.rs`.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {
         mod $mod_name {

--- a/tests/core/i128.rs
+++ b/tests/core/i128.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::i128`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::i128`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};

--- a/tests/core/u008.rs
+++ b/tests/core/u008.rs
@@ -1,8 +1,7 @@
-//! Galois-law proptest battery for `conn::std::u8`.
+//! Galois-law proptest battery for `core::u008`.
 //!
 //! Hosted as an integration test (separate crate) so the lib-test
-//! binary stays small — same precedent as
-//! `tests/conn_fixed_u<width>_galois.rs`.
+//! binary stays small — same precedent as `tests/fixed/u008.rs`.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};

--- a/tests/core/u016.rs
+++ b/tests/core/u016.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::u16`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::u016`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};
@@ -11,7 +11,7 @@ use proptest::prelude::*;
 
 // Tests `galois_upper` only; `galois_lower` is intentionally
 // omitted (fails by design for `Conn::new_left` at saturation
-// plateaus). See `tests/conn_std_u8_galois.rs` for the worked
+// plateaus). See `tests/core/u008.rs` for the worked
 // counter-example.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {

--- a/tests/core/u032.rs
+++ b/tests/core/u032.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::u32`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::u032`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};
@@ -10,7 +10,7 @@ use connections::core::{
 use proptest::prelude::*;
 
 // `galois_lower` intentionally omitted; see
-// `tests/conn_std_u8_galois.rs`.
+// `tests/core/u008.rs`.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {
         mod $mod_name {

--- a/tests/core/u064.rs
+++ b/tests/core/u064.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::u64`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::u064`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};
@@ -10,7 +10,7 @@ use connections::core::{
 use proptest::prelude::*;
 
 // `galois_lower` intentionally omitted; see
-// `tests/conn_std_u8_galois.rs`.
+// `tests/core/u008.rs`.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {
         mod $mod_name {

--- a/tests/core/u128.rs
+++ b/tests/core/u128.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::std::u128`. Integration
-//! test — see `tests/conn_std_u8_galois.rs` for rationale.
+//! Galois-law proptest battery for `core::u128`. Integration
+//! test — see `tests/core/u008.rs` for rationale.
 
 #[allow(unused_imports)]
 use connections::conn::{ConnL, ConnR};
@@ -10,7 +10,7 @@ use connections::core::{
 use proptest::prelude::*;
 
 // `galois_lower` intentionally omitted; see
-// `tests/conn_std_u8_galois.rs`.
+// `tests/core/u008.rs`.
 macro_rules! single_sided_props {
     ($mod_name:ident, $CONN:path, $arb_src:expr, $arb_tgt:expr) => {
         mod $mod_name {

--- a/tests/fixed/u008.rs
+++ b/tests/fixed/u008.rs
@@ -1,15 +1,16 @@
-//! Galois-law proptest battery for `conn::fixed::u008`.
+//! Galois-law proptest battery for `fixed::u008`.
 //!
-//! Hosted as an integration test (separate crate) so the main lib
-//! test binary doesn't carry all 252 generated test functions for
-//! this module — the unsigned binary-fixed sprint added enough new
+//! Hosted in the integration-test crate (`tests/fixed.rs`
+//! aggregator + `#[path]`-mounted siblings) so the main lib-test
+//! binary doesn't carry all the generated test functions for this
+//! module — the unsigned binary-fixed sprint added enough new
 //! tests to push the lib-test rustc invocation past CI's container
-//! memory budget. Each `tests/conn_fixed_u<width>_galois.rs` is a
-//! standalone rustc invocation, so peak memory per compile stays
-//! within budget.
+//! memory budget. The integration-test compilation gets its own
+//! rustc invocation, so peak memory per compile stays within
+//! budget.
 //!
 //! Spot tests stay collocated with the source in
-//! `src/conn/fixed/u008.rs` — they're cheap to compile.
+//! `src/fixed/u008.rs` — they're cheap to compile.
 
 use connections::fixed::u008::*;
 use fixed::FixedU8;

--- a/tests/fixed/u016.rs
+++ b/tests/fixed/u016.rs
@@ -1,8 +1,8 @@
-//! Galois-law proptest battery for `conn::fixed::u016`.
+//! Galois-law proptest battery for `fixed::u016`.
 //!
-//! See `tests/conn_fixed_u08_galois.rs` for the rationale: this is
-//! an integration test rather than a `#[cfg(test)] mod` inside
-//! `src/conn/fixed/u016.rs` to keep the lib-test rustc invocation
+//! See `tests/fixed/u008.rs` for the rationale: this is an
+//! integration test rather than a `#[cfg(test)] mod` inside
+//! `src/fixed/u016.rs` to keep the lib-test rustc invocation
 //! under CI's container memory budget.
 
 use connections::fixed::u016::*;

--- a/tests/fixed/u032.rs
+++ b/tests/fixed/u032.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::fixed::u032`. Integration
-//! test — see `tests/conn_fixed_u08_galois.rs` for rationale.
+//! Galois-law proptest battery for `fixed::u032`. Integration
+//! test — see `tests/fixed/u008.rs` for rationale.
 
 use connections::fixed::u032::*;
 use fixed::FixedU32;

--- a/tests/fixed/u064.rs
+++ b/tests/fixed/u064.rs
@@ -1,5 +1,5 @@
-//! Galois-law proptest battery for `conn::fixed::u064`. Integration
-//! test — see `tests/conn_fixed_u08_galois.rs` for rationale.
+//! Galois-law proptest battery for `fixed::u064`. Integration
+//! test — see `tests/fixed/u008.rs` for rationale.
 
 use connections::fixed::u064::*;
 use fixed::FixedU64;

--- a/tests/fixed/u128.rs
+++ b/tests/fixed/u128.rs
@@ -1,8 +1,8 @@
-//! Galois-law proptest battery for `conn::fixed::u128`. Integration
-//! test — see `tests/conn_fixed_u08_galois.rs` for rationale.
+//! Galois-law proptest battery for `fixed::u128`. Integration
+//! test — see `tests/fixed/u008.rs` for rationale.
 //!
 //! u128 generators are expensive; case count capped to 64 (same
-//! precedent as `conn::fixed::i128`).
+//! precedent as `fixed::i128`).
 
 use connections::fixed::u128::*;
 use fixed::FixedU128;


### PR DESCRIPTION
Second pre-publish polish pass on the `connections` crate. Four
concerns:

1. **LX sentinel** — a transparent byte array wrapper whose default
   lex `Ord` matches the source's numeric order. Closes the only
   gap in the byte-encoding ladder where lex compare disagreed with
   numeric compare; lets the crate produce sort-correct keys for key
   value stores (LMDB / RocksDB / sled) that compare bytes directly
   without consulting Rust's `Ord` impl.
2. **NonZero unsigned widening** — 10 new `N###N###` Conns
   `NonZeroU<N> → NonZeroU<M>` for every `N < M` across {8,16,32,
   64,128}. Mirrors the existing `U###U###` widening family at the
   NonZero layer; closes the user-flagged gap.
3. **NonZero narrowing (added mid-sprint)** — 20 new `N###N###`
   Conns via two new macros `nz_int_narrow!` and `nz_uint_narrow!`
   (10 each, one per N > M pair). The matching `nz_int_widen!` was
   investigated and **permanently dropped** as unsound on the bare
   `Conn` type — see "NonZero narrowing" section below.
4. **Audit polish** — leftover items from the four-agent code-health
   audit that didn't land in plan-01, plus a kani-tree path sweep
   triggered by user-flagged drift after the Plan-26 `core/`/`fixed/`
   split.

### LX (T1-T2)

- `connections::core::LX<const N: usize>(pub [u8; N])` — new
  wrapper with default-derived `Ord` (raw lex on the bytes). No
  custom `Ord` impl: the whole contract is that the bytes
  themselves are the sort key. Big-endian by construction; LE
  physical bytes can't serve as lex keys.
- Five signed-int isos: `I008LX01`, `I016LX02`, `I032LX04`,
  `I064LX08`, `I128LX16`, hosted source-side per the existing
  byte-encoding precedent (`I008BE01` lives in `src/core/i008.rs`).
  Each is `iso!`-declared (degenerate Galois iso, full triple).
  Encoder biases by `1 << (bits-1)` then big-endian; decoder
  unbiases. Property suite on `I008LX01` covers iso-roundtrip /
  galois L+R / floor_le_ceil / order-preservation (the key
  invariant for KV).

### NonZero unsigned widening (T3-T4)

- `nz_uint_widen!` macro added to `src/core.rs` next to
  `nz_uint_ext!`. Generates `pub const NAME: Conn<NonZeroUN,
  NonZeroUM, L>` — left-Galois single-sided, mirroring `uint_uint!`
  at the NonZero layer. `ceil` lossless-widens (no zero gap because
  `NonZeroU<N> ≥ 1`); `inner` saturates at `NonZeroU<N>::MAX`.
- 10 Conns landed in `src/core/uNNN.rs` (source-side per CLAUDE.md
  placement rule): `N008N016` … `N064N128`. Spot tests on
  `N008N016` for boundary saturation behavior; galois-L proptest
  battery on every (N,M) pair.
- Macro added to `connections::macros` re-export under the
  `macros` feature; docs table in `src/lib.rs` extended with rows
  for `nz_uint_widen!` and `law_battery!`.

### NonZero narrowing (added mid-sprint)

User flagged three missing macros in `doc/notes/note-2026-05-19-01.md`
(NonZero Conns section): `nz_int_widen!`, `nz_int_narrow!`,
`nz_uint_narrow!`. After investigation, only the two narrowing
macros are soundly expressible as bare `Conn<NonZero<i_N>,
NonZero<i_M>>`.

**`nz_int_narrow!`** — signed `NonZero<i_N> → NonZero<i_M>` with
N > M, left-Galois. `ceil` saturates source values to `i_M::MIN` /
`i_M::MAX` (both nonzero, so no zero gap reappears); `inner`
lossless-widens with the FINE_MAX fixup pattern from
`int_int_narrow!`. 10 Conns spanning every (N, M) pair with N > M:
`N016N008`; `N032N{008,016}`; `N064N{008,016,032}`;
`N128N{008,016,032,064}`. Source-side hosting in `src/core/iNNN.rs`.

**`nz_uint_narrow!`** — unsigned `NonZero<u_N> → NonZero<u_M>` with
N > M, left-Galois. `ceil` saturates above `u_M::MAX`; no low-end
branch (`NonZero<u_N> ≥ 1 > 0 = u_M::MIN`). `inner` lossless-widens
with FINE_MAX fixup. 10 Conns mirror the signed narrowing tier:
`N016N008`; `N032N{008,016}`; `N064N{008,016,032}`;
`N128N{008,016,032,064}`. Source-side hosting in `src/core/uNNN.rs`.

Per-source signed/unsigned name collision (`core::i016::N016N008` vs
`core::u016::N016N008`) is resolved by qualified-import per
CLAUDE.md's collision rule.

**Why `nz_int_widen!` was dropped.** Mirror the unsigned widening
template at the signed layer:

- `ceil`: lossless embedding `NZ<i_N> → NZ<i_M>` (N < M).
- `inner`: saturate target values outside `[i_N::MIN, i_N::MAX]` to
  the matching boundary.

Implementing this and running the L-Galois proptest (with a=NZ(-128),
b=NZ(-129)) gives: `ceil(a) = NZ(-128)`, LHS `NZ(-128) ≤ NZ(-129)` is
**false**; `inner(b) = NZ(i_N::MIN) = NZ(-128)`, RHS `a ≤ inner(b)` is
**true**. L-Galois violated. R-Galois fails symmetrically at the upper
plateau. The root cause: the target range `[i_M::MIN, i_N::MIN as
i_M − 1]` has no representative in `NonZero<i_N>` (the supremum of an
empty set requires a `-Inf` sentinel that `NonZero<i_N>` doesn't
provide). Contrast `nz_uint_widen!`, where the lower bound
`u_N::MIN = 0 < 1 = NonZero<u_M>::MIN` makes that target range
empty.

Workaround for downstream users: compose `nz_int_ext!` +
`ext_int!` to widen via `i_N → Extended<i_N> → i_M → NonZero<i_M>`.
A future `nz_int_widen!` would need new `Extended<NonZero<i_N>>`
infrastructure; out of scope here.

### Stale-path sweep

User flagged 3 stale `crate::fixed::iNNN` references in
`src/kani/nz_ext.rs` + 2 hifi doc comments. The same drift existed
across 5 more kani harnesses — sweep-fixed:

- `src/kani/{ext_int,int_narrow,uint_narrow,uint_sat,uint_widen}.rs`:
  all importing the moved consts via `crate::fixed::iNNN` /
  `crate::fixed::uNNN`. Silent in `cargo build` / `cargo test`
  because `src/kani/` is `cfg(all(kani, feature = "fixed"))`-gated;
  would fail under `cargo kani`. Rewired to per-source-module paths
  (`crate::core::iNNN` / `uNNN`).
- Reorganised each harness's grouping from per-destination to
  per-source so the import path matches the actual hosting after
  the Plan-26 split.
- Legitimate `fixed::iNNN` / `uNNN` imports preserved in
  `iso_family.rs` and `fix_fix_*.rs` (Q-format Conns genuinely host
  in `src/fixed/`).

### Polish (T5-T11)

- Doctest-style fixes in `src/core/f032.rs` and `src/core/f064.rs`:
  replaced tautological `assert!(x <= y)` / `assert!(x >= y)`
  bracketing with `assert_eq!` against named f16/f32 grid points
  around PI. Aligns with memory `feedback_doctest_style`.
- `#[cfg_attr(docsrs, doc(cfg(feature = "f16")))]` mirrors on
  `F032F016` and `F064F016` — completes the docsrs feature-mirror
  story.
- 17+ GitLab `MR !63…!69 round-N` parentheticals removed from
  `src/hifi/{calendar,epoch,duration}.rs` (frozen archive refs with
  no GitHub equivalent).
- `lib.rs` macros table extended with `nz_uint_widen!` and
  `law_battery!` rows; both added to `connections::macros::*`
  re-export.
- Stale "for backward-compat during the migration" prose deleted
  from `src/fixed.rs:60-78` (migration is done).
- `src/lib.rs:13` F016 row repointed at `float::F016` (the actual
  type location).
- `src/interval.rs:68` — added `Hash` to `Interval<A>`'s derive
  pack. Surprising absence given `Eq` was already there.
- `tests/core/*.rs` and `tests/fixed/*.rs` headers swept of stale
  `conn::std::iN` / `conn::fixed::uN` references (pre-rename module
  paths).

## Test plan

- `cargo test --features fixed,time,hifi,macros,proptest` — 4922
  passing (1827 lib +22 from LX/N###N### properties — adds 20 new
  narrowing-pair galois props + 2 narrow-pair spot tests over the
  previous round; 90 doctests +1 for I008KV01), 14 doctests ignored
  per existing harness.
- `cargo clippy --all-targets --features fixed,time,hifi,macros,
  proptest -- -D warnings` — clean.
- `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc
  --no-deps --features fixed,proptest,macros,time` — clean.
- Spot checks: `I008KV01` boundary table (MIN→0x00, 0→0x80,
  MAX→0xFF), `N008N016` saturation at `u8::MAX`, `N016N008`
  both-plateau saturation + FINE_MAX fixup.

## Deferred

See `doc/plans/plan-2026-05-19-02.md § Review`.
