### PR TITLE
uhlc Conns: NDURU064 (NTP64 ↔ u64 iso) + HLIDLX16 (ID ↔ LX<16>, R-only)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -35,7 +35,7 @@ fi
 
 # 1. cargo test — blocking. Single-crate, no --workspace.
 step "cargo test --quiet"
-cargo test --features fixed,time,hifi,proptest,macros --quiet
+cargo test --features fixed,time,hifi,uhlc,proptest,macros --quiet
 
 # 2. cargo clippy — blocking.
 step "cargo clippy --all-targets --quiet -- -D warnings"
@@ -44,7 +44,7 @@ cargo clippy --all-targets --quiet -- -D warnings
 # 3. cargo doc — blocking. Catches broken intra-doc links and rustdoc
 #    warnings before they reach CI. Mirrors the `.github/workflows/ci.yml`
 #    `doc` job's invocation so the local check and CI agree.
-step "cargo doc --no-deps --features fixed,proptest,macros,time --document-private-items"
-RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features fixed,proptest,macros,time --document-private-items
+step "cargo doc --no-deps --features fixed,proptest,macros,time,uhlc --document-private-items"
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features fixed,proptest,macros,time,uhlc --document-private-items
 
 step "OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --features fixed,time,hifi,proptest,macros
-      - run: cargo test --doc --features fixed,time,hifi,proptest,macros
+      # `--jobs 2` caps parallel rustc instances so the test build's
+      # peak memory stays under the GHA runner's ~7 GB budget. Without
+      # it, the proptest-heavy test binaries randomly OOM-kill the
+      # runner (exit 143) right around the link stage — see PR #8
+      # rounds 2/3 for the failure pattern. Wall-clock cost is ~2×
+      # over uncapped, still well under any job-timeout limit.
+      - run: cargo test --jobs 2 --features fixed,time,hifi,uhlc,proptest,macros
+      - run: cargo test --jobs 2 --doc --features fixed,time,hifi,uhlc,proptest,macros
 
   doc:
     runs-on: ubuntu-latest
@@ -38,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --no-deps --features fixed,proptest,macros,time --document-private-items
+      - run: cargo doc --no-deps --features fixed,proptest,macros,time,uhlc --document-private-items
 
   deny:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: model-checking/kani-github-action@v1.1
         with:
-          args: '--features hifi'
+          args: '--features fixed,hifi,uhlc'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - run: cargo doc --no-deps --features fixed,proptest,macros,time --document-private-items
+      - run: cargo doc --no-deps --features fixed,proptest,macros,time,uhlc --document-private-items
       - run: echo '<meta http-equiv="refresh" content="0; url=connections/">' > target/doc/index.html
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,8 @@ Per-domain Conn families:
 | `core`    | `core`/`std` (i8…u128, f16/f32/f64, char, bool, NonZero) | `i008.rs`–`i128.rs`, `u008.rs`–`u128.rs` (std-int + NonZero), `f016.rs`/`f032.rs`/`f064.rs` (IEEE), `char.rs`, `bool.rs` |
 | `fixed`   | `fixed`                                    | `i008.rs`–`i128.rs`, `u008.rs`–`u128.rs` (Q-format + cross-crate iso `I###Q000` + float-bridge `F0XXQ###`) |
 | `time`    | `time`, `std::time`                        | `clock.rs`, `date.rs`, `datetime.rs`, `duration.rs`, `offset.rs` |
+| `hifi`    | `hifitime`                                 | `duration.rs`, `epoch.rs`, `calendar.rs` |
+| `uhlc`    | `uhlc`                                     | `ntp64.rs`, `id.rs` |
 | `float`   | (this crate)                               | `ExtendedFloat<T>` + ULP/rounding helpers + `float_ext_int!` macros |
 | `addr`    | `std::net`                                 | `ip.rs`, `socket.rs` |
 | `conn`    | (this crate)                               | `Conn<A, B, K>`, `compose!` / `triple!` / `iso!` macros, free fns operating on a `Conn` |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ fixed = { version = "1", optional = true }
 time = { version = ">=0.3, <0.3.46", optional = true }
 hifitime = { version = "4.3", optional = true, default-features = false }
 proptest = { version = "1", optional = true }
+uhlc = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 proptest = "1"
@@ -91,6 +92,13 @@ f16 = []
 # can re-enable the corresponding hifitime features themselves.
 hifi = ["dep:hifitime"]
 
+# Enable HLC bridge Conns under `connections::uhlc::*` backed by the
+# `uhlc` crate. Pulled with `default-features = false` to skip
+# `uhlc`'s default `["std", "serde"]` (which would drag in
+# `humantime`, `lazy_static`, `log`, `rand/std`) — the iso /
+# right-Galois Conns shipped here only need the bare types.
+uhlc = ["dep:uhlc"]
+
 # Re-export the crate's internal codegen macros under
 # `connections::macros` for downstream crates building their own
 # bounded-integer / Q-format / NonZero / iso lattices on top of
@@ -112,7 +120,7 @@ macros = []
 # `#[cfg_attr(docsrs, doc(cfg(feature = "proptest")))]` mirrors that
 # surface the gating in the rendered docs.
 [package.metadata.docs.rs]
-features = ["fixed", "proptest", "macros", "time"]
+features = ["fixed", "proptest", "macros", "time", "hifi", "uhlc"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 # Declare `cfg(kani)` so `cargo build` / `cargo test` don't warn about

--- a/doc/plans/plan-2026-05-19-03.md
+++ b/doc/plans/plan-2026-05-19-03.md
@@ -645,9 +645,43 @@ assert_eq!(lex_min_id.to_le_bytes(), expected);              // saturates up to 
   encounter the saturation boundary in practice.
 - Loosening `lib.rs:251` to allow `cargo kani` without `--features
   fixed` — the outer gate currently bundles all Kani proofs together;
-  splitting them across feature axes is a refactor outside this sprint.
+  splitting them across feature axes is a refactor outside this
+  sprint. Today, `cargo kani --features fixed,hifi,uhlc` exercises
+  the full Kani suite.
 
 ## Review
 
-(Filled in at finalize time after T5 passes — `#[ignore]`d properties
-with re-enablement plans, design deviations, drift caught, recommendations.)
+### Design notes
+
+- **Const-fn relaxed for `id_to_lx16`**. The plan sketch had it as a
+  const fn for parity with the NonZero macro family; `ID::to_le_bytes`
+  is not const, so it must be a regular `fn`. `Conn::new_l` / `new_r`
+  take bare `fn` pointers, which don't need to be const, so this is a
+  no-op for the Conn type — `NDURU064` and `HLIDLX16` remain `Copy +
+  Default + const`-built.
+- **`Debug` workaround**. Neither `NTP64` nor `ID` derive `Debug`, so
+  proptest strategies can't yield them directly (proptest requires
+  `Debug` on `Strategy::Value` for failure rendering). Strategies
+  generate raw `u64` / non-zero `u128`; bodies construct the domain
+  types. Documented inline in each `mod tests`.
+
+### Drift caught (gardener rule)
+
+| File | Rule | Action |
+|------|------|--------|
+| `AGENTS.md:147-150` (per-domain table) | "Every Conn submodule has a row" | Added missing `hifi` row alongside the new `uhlc` row. Single-file, no API change. Fixed here. |
+| `Cargo.toml:115` (`[package.metadata.docs.rs]`) | docs.rs feature set should cover all gated submodules | Added `hifi` + `uhlc`. Single-line. Fixed here. |
+| `.github/workflows/ci.yml`, `pages.yml`, `kani.yml`, `.githooks/pre-push` | feature lists should cover all optional submodules | Added `uhlc` to every feature-set in the chain. In scope per T1. |
+
+### Recommendations
+
+- The proptest "raw-u64 / non-zero u128 in, build domain type in
+  body" idiom should be standardised: a future plan could add a tiny
+  `arb_ntp64()` / `arb_id()` helper to `prop::arb` (already gated on
+  `feature = "proptest"`) so downstream uhlc users can re-use it.
+  Deferred — only two call sites today, both in this PR.
+- The `l_law_fails_at_puncture` regression test pattern (build an
+  ad-hoc `Conn<A, B, L>` from an R-only pair to assert L fails) is a
+  useful idiom for any one-sided Conn whose other side fails at a
+  documented corner; consider lifting it into `prop::conn` as a
+  `negative_galois_l` predicate if a second example shows up.

--- a/doc/plans/plan-2026-05-19-03.md
+++ b/doc/plans/plan-2026-05-19-03.md
@@ -1,0 +1,653 @@
+# Plan 03 — `src/uhlc/` module, feature-gated on `uhlc`
+
+## Goal
+
+Ship a feature-flagged `src/uhlc/` module bridging the
+[`uhlc-rs`](https://crates.io/crates/uhlc) HLC types — `NTP64` and `ID` —
+to existing integer / byte endpoints via two Galois connections: a full
+iso `NDURU064` and a one-sided right-Galois `HLIDLX16`. The connection
+types each claim exactly the laws that hold; no panics; cross-width
+chains are reachable by composition against the existing `core::u064`
+ladder.
+
+## Dependency Graph
+
+T1 (Cargo.toml + lib.rs/kani.rs gates) → T2 (`src/uhlc.rs` + `ntp64.rs` +
+`id.rs`) → T3 (proptest batteries) → T4 (Kani harnesses) → T5 (build
+gates green) → T6 (finalize + review).
+
+## Pre-conditions (already satisfied on `origin/main`)
+
+The `KV<N>` → `LX<N>` rename landed with pull/7 (`a67e082`):
+
+- `pub struct LX<const N: usize>` at `src/core.rs:233`.
+- Rustdoc at `src/core.rs:216-232` reframes the wrapper as a sentinel
+  for lexicographically ordered byte arrays; integer-key DB use is the
+  motivating consumer but no longer the only one.
+- The "Big-endian by construction" sentence is gone.
+- `IxxxLXxy` consts in `src/core/{i008,…,i128}.rs`.
+
+The uhlc module therefore consumes `crate::core::LX<16>` as
+opaque-bytes — the documented contract — with no further rename
+follow-up.
+
+## Scope
+
+### Tasks
+
+**T1 — Cargo / lib / kani wiring.** Add an optional `uhlc` dependency
+with `default-features = false` (so we don't drag in `humantime`,
+`lazy_static`, `log`, `rand/std` from `uhlc`'s default `["std",
+"serde"]`); declare the `uhlc` feature; declare `#[cfg(feature =
+"uhlc")] pub mod uhlc;` in `lib.rs`; add the corresponding `mod uhlc;`
+under `src/kani.rs`. The outer Kani gate at `lib.rs:251` is
+`#[cfg(all(kani, feature = "fixed"))]`; the uhlc Kani harnesses sit
+under it and therefore require `cargo kani --features fixed,uhlc`.
+Loosening the outer gate is out of scope.
+
+**T2 — `src/uhlc/ntp64.rs` (`NDURU064`).** `iso!`-built marker struct
+bridging `uhlc::NTP64 ↔ u64`. `NTP64(pub u64)` is a transparent newtype
+with no internal invariant; the forward/back pair is direct field
+access. Const-fn pair so the marker is `Copy + Default + const`-built.
+
+**T3 — `src/uhlc/id.rs` (`HLIDLX16`).** `conn_r!`-built `pub const
+HLIDLX16: Conn<ID, LX<16>, R>`. The `inner` direction
+(`lx16_to_id`) is total via saturating the single `LX([0;16])` puncture
+*up* to the lex-min valid `ID` (the byte array `[0,…,0,1]`); the
+`floor` direction is lossless. No panics; the only `Result`-bearing
+call (`ID::try_from(&[u8;16])`) is fed bytes that are provably non-zero
+at every reachable call site, and the `unreachable!()` branch is dead
+code under that precondition.
+
+**T4 — `src/kani/uhlc.rs`.** Kani harnesses mirroring `src/kani/nz_ext.rs`:
+NDURU064 gets the iso battery (`galois_l`, `galois_r`, `iso_roundtrip_l`,
+`floor_le_ceil` — `closure_l`/`closure_r` are weaker forms of
+`iso_roundtrip_l` and not separately proven on an iso); HLIDLX16 gets
+the R-only battery (`galois_r`, `closure_r`, `kernel_r`, `monotone_r`)
+plus `lower_never_panics` over the *full* `[u8; 16]` domain with **no
+`kani::assume`** — proving totality. `roundtrip_floor` is exercised
+by proptest only (in `uhlc::id::tests`), not duplicated as a Kani
+harness; the totality proof + the four R-laws already pin down the
+behavior at every input.
+
+**T5 — Build-gate sweep.** `cargo build --no-default-features`,
+`cargo build --features uhlc`, `cargo test --features uhlc`, `cargo
+clippy --features uhlc --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D
+warnings cargo doc --features uhlc --no-deps`. CI: add a `uhlc` cell in
+`.github/workflows/` mirroring `--features hifi`.
+
+**T6 — Sprint-doc finalize.** Append Deferred + Review sections to this
+plan; create `doc/reviews/review-NNNNN.md` (slot determined at finalize
+time via `scripts/pr_report.py path`) with `# PR #N — title` +
+`## Summary`. Run `scripts/pr_review.sh`. Open the PR via
+`gh pr create --body-file <(scripts/pr_report.py body N)`.
+
+### Surface (final)
+
+| Conn       | Endpoints                | Law        | Macro      |
+|------------|--------------------------|------------|------------|
+| `NDURU064` | `NTP64 ↔ u64`            | iso (full) | `iso!`     |
+| `HLIDLX16` | `ID ↔ LX<16>`            | R-only     | `conn_r!`  |
+
+#### `HLIDLX16` derivation rationale
+
+A naive iso to `NonZero<u128>` (or to `LE<16>`) would fail Galois:
+`ID`'s derived `Ord` is byte-lex from byte 0 of its LE-stored
+`[u8; 16]` (**LSB-first**), while both `NonZero<u128>` and `LE<16>`
+order numerically (MSB-first). Counter-example: `ID::from(NZ(1))`
+stores `[1, 0, …, 0]` and `ID::from(NZ(256))` stores `[0, 1, 0, …, 0]`;
+under ID's Ord `ID(1) > ID(256)` (byte 0: 1>0), but under integer Ord
+`1 < 256`. So Galois fails on both candidate targets.
+
+`LX<16>` carries the same derived (lex-from-byte-0) `Ord` as
+`[u8; 16]`. Orders on both sides of `ID ↔ LX<16>` match — except that
+`LX([0; 16])` is one byte string no `ID` represents. The structural
+fix is the mirror of `nz_uint_ext!`'s shape: saturate the puncture to a
+sentinel, ship as a single-sided Conn.
+
+**Why R-only.** At the puncture `b = LX([0;16])` with
+`inner(b) = ID([0,…,0,1])` (the lex-min valid ID):
+
+- **R-law** `inner(b) ≤ a ⟺ b ≤ floor(a)`: both sides hold for every
+  valid `a` (`ID([0,…,0,1])` is the lex-min ID; `LX([0;16])` is the
+  lex-min `LX`). Both sides always true → R holds. ✓
+- **L-law** `ceil(a) ≤ b ⟺ a ≤ inner(b)`: at
+  `(a = ID([0,…,0,1]), b = LX([0;16]))`, LHS `LX(a.0) ≤ LX([0;16])`
+  is *false* (any valid ID's bytes are strictly above `[0;16]`
+  lex), RHS `a ≤ ID([0,…,0,1]) = a` is *true*. ✗ Mismatch.
+
+So R holds but L fails — ship via `conn_r!`. Exact mirror of
+`nz_uint_ext!` (L-only because *its* puncture sits on the source
+side instead).
+
+### Explicitly deferred (not in v1)
+
+- `NTP64 ↔ core::time::Duration` — `From<Duration> for NTP64` panics
+  for `secs > u32::MAX` (`uhlc-rs/src/ntp64.rs:287-293`); needs
+  saturating-ceil treatment, L-only by the `nz_uint_ext!` pattern.
+- `Timestamp ↔ anything` — `Timestamp = (NTP64, ID)` lex-ordered
+  composite; no single integer endpoint preserves the order without
+  inventing a `u192`.
+- Cross-width pre-baking (`NDURU032`, `HLIDLX08`, …) — composable
+  from v1 Conns + the existing `core::u064` ladder.
+- `HLC`, `HLCBuilder`, `ExceedingDeltaError` — live-clock builder
+  and errors. Not values that participate in an order; no Conn
+  applies.
+
+## Naming
+
+Per the 8-char rule:
+
+| Side code | Type            | Form | Notes                                                  |
+|-----------|-----------------|------|--------------------------------------------------------|
+| `NDUR`    | `uhlc::NTP64`   | ABCD | "NTP Duration"; parallels `TDUR`/`HDUR`                |
+| `HLID`    | `uhlc::ID`      | ABCD | "HLC node ID"                                          |
+| `U064`    | `u64`           | A123 | existing (`core::u064`)                                |
+| `LX16`    | `LX<16>`        | AB12 | renamed wrapper family (parallel to `LE16`, `B216`)    |
+
+Resulting Conn names: `NDURU064`, `HLIDLX16`. Both 8 chars, 4+4.
+
+**Why `NDUR` not `ENTP`:** the `E***` family in `src/hifi/epoch.rs`
+encodes a typed reference epoch (J1900 TAI, J1900 UTC, UNIX EPOCH UTC,
+…) — nine scale tags. `NTP64` is clock-agnostic
+(`uhlc-rs/src/ntp64.rs:68-71`: "NTP64 has no built-in EPOCH; only
+`to_system_time()` and `{:#}` display assume UNIX_EPOCH") with a single
+scale, so `E***` would be a misleading mnemonic. Structurally `NTP64`
+is a fixed-unit (`2⁻³² s`) duration newtype — `NDUR` reads parallel to
+`TDUR` and `HDUR`.
+
+**Why not `NTPx`:** trailing digits on `NTP` collide with NTP protocol
+version numbers (NTPv4 is the current RFC 5905 protocol; v5 is in
+draft). `NTP4U064` would be misread as "NTPv4 Conn".
+
+**Why `HLID` not `UHID`:** the ID is specifically the **HLC node ID**,
+used to disambiguate concurrent timestamps from different nodes
+(`uhlc-rs/src/lib.rs:192-197`). Structural naming (what the type *is*)
+parallels the `NDUR` choice.
+
+Grep confirms no existing collisions in the codebase for `NDUR*` or
+`HLID*`.
+
+## Files to add / modify
+
+### New
+
+- `src/uhlc.rs` — module rustdoc + `pub mod ntp64; pub mod id;` +
+  `pub use` re-exports.
+- `src/uhlc/ntp64.rs` — `NDURU064` (`iso!`) + proptest battery.
+- `src/uhlc/id.rs` — `HLIDLX16` (`conn_r!`) + proptest battery +
+  negative L-law unit test.
+- `src/kani/uhlc.rs` — Kani harnesses for both Conns.
+
+### Modified
+
+- `Cargo.toml` — `uhlc = { version = "0.9", optional = true,
+  default-features = false }`, `uhlc = ["dep:uhlc"]` feature.
+- `src/lib.rs` — `#[cfg(feature = "uhlc")] pub mod uhlc;` next to
+  `hifi`; add a row to the feature-table doc comment.
+- `src/kani.rs` — `#[cfg(feature = "uhlc")] mod uhlc;` next to the
+  existing `hifi`/`time`-gated modules.
+- `CLAUDE.md` (=`AGENTS.md`) — one row in the "Per-domain Conn
+  families" table.
+- `.github/workflows/*.yml` — add a `uhlc`-features matrix cell
+  mirroring `hifi`.
+- `Cargo.lock` — regenerated.
+
+## Implementation sketch
+
+### `src/uhlc/ntp64.rs`
+
+The `iso!` macro requires `forward: $expr, back: $expr` — function
+*names* (or closures), not destructuring patterns. Define const fns
+and pass them by name:
+
+```rust
+//! `NTP64 ↔ u64` iso. `NTP64` is a transparent newtype with no internal
+//! invariant; the inner `u64` is `pub`.
+
+use uhlc::NTP64;
+
+const fn ntp64_to_u64(t: NTP64) -> u64 {
+    t.0
+}
+const fn u64_to_ntp64(n: u64) -> NTP64 {
+    NTP64(n)
+}
+
+crate::iso! {
+    /// `NTP64 ↔ u64` — lossless iso over the transparent newtype.
+    pub NDURU064 : NTP64 => u64 {
+        forward: ntp64_to_u64,
+        back:    u64_to_ntp64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conn::{ConnL, ConnR};
+    use crate::prop::conn as conn_laws;
+    use proptest::prelude::*;
+
+    fn arb_ntp64() -> impl Strategy<Value = NTP64> {
+        prop_oneof![
+            Just(NTP64(0)),
+            Just(NTP64(u64::MAX)),
+            any::<u64>().prop_map(NTP64),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn iso_roundtrip_l(t in arb_ntp64()) {
+            prop_assert!(conn_laws::iso_roundtrip_l(&NDURU064.conn_l(), t));
+        }
+        #[test]
+        fn roundtrip_ceil(n in any::<u64>()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&NDURU064.conn_l(), n));
+        }
+        #[test]
+        fn galois_l(t in arb_ntp64(), n in any::<u64>()) {
+            prop_assert!(conn_laws::galois_l(&NDURU064.conn_l(), t, n));
+        }
+        #[test]
+        fn galois_r(t in arb_ntp64(), n in any::<u64>()) {
+            prop_assert!(conn_laws::galois_r(&NDURU064.conn_r(), t, n));
+        }
+        #[test]
+        fn floor_le_ceil(t in arb_ntp64()) {
+            prop_assert!(conn_laws::floor_le_ceil(&NDURU064, t));
+        }
+    }
+}
+```
+
+(`NTP64`'s derived `Ord` is over the inner `u64`
+(`uhlc-rs/src/ntp64.rs:73-76`), so `floor_le_ceil` and the Galois laws
+all type-check.)
+
+### `src/uhlc/id.rs`
+
+```rust
+//! `Conn<ID, LX<16>, R>` — right-Galois only. `ID` is a 16-byte
+//! LE-stored token whose derived Ord is byte-lex from byte 0 (i.e.,
+//! LSB-first under LE storage); `LX<16>` is the identity byte-wrapper
+//! with the same derived Ord. `LX<16>` carries one value
+//! (`LX([0; 16])`) that no `ID` represents — `ID`'s construction
+//! enforces a non-zero `u128` invariant. Total-via-saturation: the
+//! puncture maps to the lex-min valid ID. L-Galois fails at that
+//! boundary; R-Galois holds. See the plan for the corner-case
+//! derivation.
+
+use uhlc::ID;
+
+use crate::core::LX;
+
+/// Lex-min valid `ID` under the byte-lex-from-byte-0 Ord — byte 15 =
+/// 1, all other bytes 0. Numerically this is `1 << 120`, but under
+/// ID's derived Ord it is the minimum.
+const LEX_MIN_ID_BYTES: [u8; 16] = {
+    let mut b = [0u8; 16];
+    b[15] = 1;
+    b
+};
+
+const fn id_to_lx16(id: ID) -> LX<16> {
+    LX(id.to_le_bytes())
+}
+
+fn lx16_to_id(lx: LX<16>) -> ID {
+    // ID::try_from(&[u8; 16]) errors only on all-zero input. We make
+    // the function total by routing the single puncture (`LX([0; 16])`)
+    // to the lex-min valid ID — the saturation that justifies the
+    // R-Galois law (see plan). Both branches feed `ID::try_from` a
+    // provably non-zero `&[u8; 16]`, so the `Err` arm is dead code at
+    // every reachable input; `unreachable!()` documents that
+    // statically. **No panics on reachable inputs.**
+    let bytes: &[u8; 16] = if lx.0 == [0u8; 16] {
+        &LEX_MIN_ID_BYTES
+    } else {
+        &lx.0
+    };
+    ID::try_from(bytes).unwrap_or_else(|_| unreachable!())
+}
+
+crate::conn_r! {
+    /// `Conn<ID, LX<16>, R>` — ID's 16-byte representation with
+    /// saturating decode at the all-zero byte string.
+    ///
+    /// - `.floor(id)` (lossless): `id` → its LE-bytes-as-`LX<16>`.
+    /// - `.lower(lx)` (saturating): valid bytes round-trip; the single
+    ///   all-zero `LX([0; 16])` value saturates *up* to the lex-min
+    ///   valid `ID` (`ID::from(NonZeroU128::new(1 << 120).unwrap())`).
+    ///   R-Galois holds at this boundary; L-Galois does not — that's
+    ///   why this is a `conn_r!`, not an `iso!`.
+    pub HLIDLX16 : ID => LX<16> {
+        inner: lx16_to_id,
+        floor: id_to_lx16,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prop::conn as conn_laws;
+    use core::num::NonZeroU128;
+    use proptest::prelude::*;
+
+    fn arb_id() -> impl Strategy<Value = ID> {
+        prop_oneof![
+            Just(ID::from(NonZeroU128::new(1).unwrap())),
+            Just(ID::from(NonZeroU128::MAX)),
+            any::<u128>()
+                .prop_filter_map("non-zero u128", NonZeroU128::new)
+                .prop_map(ID::from),
+        ]
+    }
+
+    fn arb_lx16() -> impl Strategy<Value = LX<16>> {
+        prop_oneof![
+            Just(LX([0u8; 16])),
+            Just(LX([0xFFu8; 16])),
+            any::<[u8; 16]>().prop_map(LX),
+        ]
+    }
+
+    fn arb_nonpuncture_lx16() -> impl Strategy<Value = LX<16>> {
+        any::<[u8; 16]>()
+            .prop_filter("non-zero bytes", |b| *b != [0u8; 16])
+            .prop_map(LX)
+    }
+
+    proptest! {
+        #[test]
+        fn galois_r(a in arb_id(), b in arb_lx16()) {
+            prop_assert!(conn_laws::galois_r(&HLIDLX16, a, b));
+        }
+        #[test]
+        fn closure_r(a in arb_id()) {
+            prop_assert!(conn_laws::closure_r(&HLIDLX16, a));
+        }
+        #[test]
+        fn kernel_r(b in arb_lx16()) {
+            prop_assert!(conn_laws::kernel_r(&HLIDLX16, b));
+        }
+        #[test]
+        fn monotone_r(a1 in arb_id(), a2 in arb_id()) {
+            prop_assert!(conn_laws::monotone_r(&HLIDLX16, a1, a2));
+        }
+        #[test]
+        fn roundtrip_floor_nonpuncture(b in arb_nonpuncture_lx16()) {
+            // floor(lower(b)) == b on non-puncture inputs.
+            prop_assert_eq!(HLIDLX16.floor(HLIDLX16.lower(b)).0, b.0);
+        }
+    }
+
+    // ── Documented L-law mismatch at the puncture corner ──────────
+    #[test]
+    fn l_law_fails_at_puncture() {
+        // The HLIDLX16 conn is R-only; constructing an ad-hoc L-Conn
+        // from the same pair lets us assert the L-law's documented
+        // counter-example. If a future Ord change silently makes the
+        // L-law hold, this test will fail and force a revisit.
+        let l: crate::conn::Conn<ID, LX<16>> =
+            crate::conn::Conn::new_l(id_to_lx16, lx16_to_id);
+        let a = ID::try_from(&LEX_MIN_ID_BYTES).unwrap();
+        let b = LX([0u8; 16]);
+        // ceil(a) ≤ b is false (LX(a.0) = [0,...,0,1] > [0;16] lex).
+        // a ≤ inner(b) is true (inner(b) = a).
+        assert!(!conn_laws::galois_l(&l, a, b));
+    }
+
+    // ── Totality: the saturating decode is total at every LX<16> ──
+    #[test]
+    fn lower_total_at_puncture() {
+        let z = LX([0u8; 16]);
+        let id = HLIDLX16.lower(z);
+        let mut expected = [0u8; 16];
+        expected[15] = 1;
+        assert_eq!(id.to_le_bytes(), expected);
+    }
+}
+```
+
+### `src/uhlc.rs`
+
+```rust
+//! # uhlc Conns
+//!
+//! Galois connections bridging the [`uhlc`](https://docs.rs/uhlc) crate's
+//! HLC types to integer / byte endpoints. Gated on `feature = "uhlc"`.
+//!
+//! | Conn       | Endpoints       | Law        |
+//! |------------|-----------------|------------|
+//! | NDURU064   | NTP64 ↔ u64     | iso (full) |
+//! | HLIDLX16   | ID ↔ LX<16>     | R-only     |
+//!
+//! `HLIDLX16` bridges to the opaque-bytes [`LX<16>`](crate::core::LX)
+//! rather than `NonZero<u128>`: ID's derived Ord is byte-lex
+//! (LSB-first under LE storage), which is *not* the integer order on
+//! the underlying `u128`. `LX<16>`'s lex-from-byte-0 Ord matches ID's.
+//! The connection is right-Galois (not iso): `LX<16>` has the all-zero
+//! value that ID doesn't, and saturating that puncture to the lex-min
+//! valid ID breaks the L-law but preserves the R-law. See the [`id`]
+//! submodule for the derivation.
+
+pub mod id;
+pub mod ntp64;
+
+pub use id::HLIDLX16;
+pub use ntp64::NDURU064;
+```
+
+### `src/kani/uhlc.rs`
+
+Two-block file mirroring `src/kani/nz_ext.rs`:
+
+```rust
+//! Kani harnesses for [`crate::uhlc::NDURU064`] (iso) and
+//! [`crate::uhlc::HLIDLX16`] (right-Galois). For NDURU064 the standard
+//! iso battery; for HLIDLX16 the R-only battery on the full domain
+//! (Galois / closure / kernel / monotone) plus a totality proof
+//! (`lower_never_panics`) that exercises `kani::any::<[u8; 16]>()`
+//! with **no precondition** — bit-blasting CBMC over all 2¹²⁸ inputs
+//! demonstrates the function is total.
+
+use crate::conn::{ConnL, ConnR};
+use crate::core::LX;
+use crate::prop::conn as conn_laws;
+use crate::uhlc::{HLIDLX16, NDURU064, id::lx16_to_id};
+use core::num::NonZeroU128;
+use uhlc::{ID, NTP64};
+
+fn arb_id_symbolic() -> ID {
+    let n: u128 = kani::any();
+    kani::assume(n != 0);
+    ID::from(NonZeroU128::new(n).unwrap())
+}
+
+mod ndur_u064 {
+    use super::*;
+
+    #[kani::proof]
+    fn galois_l() {
+        let t = NTP64(kani::any());
+        let n: u64 = kani::any();
+        assert!(conn_laws::galois_l(&NDURU064.conn_l(), t, n));
+    }
+    #[kani::proof]
+    fn galois_r() {
+        let t = NTP64(kani::any());
+        let n: u64 = kani::any();
+        assert!(conn_laws::galois_r(&NDURU064.conn_r(), t, n));
+    }
+    #[kani::proof]
+    fn iso_roundtrip_l() {
+        let t = NTP64(kani::any());
+        assert!(conn_laws::iso_roundtrip_l(&NDURU064.conn_l(), t));
+    }
+    #[kani::proof]
+    fn floor_le_ceil() {
+        let t = NTP64(kani::any());
+        assert!(conn_laws::floor_le_ceil(&NDURU064, t));
+    }
+}
+
+mod hlid_lx16 {
+    use super::*;
+
+    #[kani::proof]
+    fn galois_r() {
+        let a = arb_id_symbolic();
+        let bytes: [u8; 16] = kani::any();
+        assert!(conn_laws::galois_r(&HLIDLX16, a, LX(bytes)));
+    }
+    #[kani::proof]
+    fn closure_r() {
+        let a = arb_id_symbolic();
+        assert!(conn_laws::closure_r(&HLIDLX16, a));
+    }
+    #[kani::proof]
+    fn kernel_r() {
+        // No assume — the R-kernel law `b ≤ floor(lower(b))` holds
+        // even at the puncture: `lower([0;16]) = ID([0,…,0,1])`,
+        // `floor(ID([0,…,0,1])) = LX([0,…,0,1])`, and `[0;16]` is
+        // lex-min so `LX([0;16]) ≤ LX([0,…,0,1])` is true.
+        let bytes: [u8; 16] = kani::any();
+        assert!(conn_laws::kernel_r(&HLIDLX16, LX(bytes)));
+    }
+    #[kani::proof]
+    fn monotone_r() {
+        let a1 = arb_id_symbolic();
+        let a2 = arb_id_symbolic();
+        assert!(conn_laws::monotone_r(&HLIDLX16, a1, a2));
+    }
+    /// **Totality.** No `kani::assume` precondition — the full
+    /// `[u8; 16]` domain, including the all-zero puncture, must
+    /// produce a value (the lex-min ID) without `unreachable!()` or
+    /// `panic!()` firing.
+    #[kani::proof]
+    fn lower_never_panics() {
+        let bytes: [u8; 16] = kani::any();
+        let _ = HLIDLX16.lower(LX(bytes));
+    }
+}
+```
+
+(The `lx16_to_id` re-export in `mod id` needs to be `pub(crate)` so the
+kani harness can reach it for the lower-never-panics proof; otherwise
+we can just call `HLIDLX16.lower(...)` and let the macro expansion
+route us through the same fn. The sketch above takes the latter, simpler
+path.)
+
+## Verification
+
+### Properties (must pass — proptest)
+
+| Property                      | Module        | Invariant                                                        |
+|-------------------------------|---------------|------------------------------------------------------------------|
+| `iso_roundtrip_l`             | `uhlc::ntp64` | `upper(ceil(t)) == t` for all `NTP64`                            |
+| `roundtrip_ceil`              | `uhlc::ntp64` | `ceil(upper(n)) == n` for all `u64`                              |
+| `galois_l`, `galois_r`        | `uhlc::ntp64` | per-side Galois laws (iso → both trivially hold)                 |
+| `floor_le_ceil`               | `uhlc::ntp64` | required for full-triple Conns                                   |
+| `galois_r`                    | `uhlc::id`    | the law this Conn ships under                                    |
+| `closure_r`                   | `uhlc::id`    | `lower(floor(a)) ≤ a` (R-closure)                                |
+| `kernel_r`                    | `uhlc::id`    | `b ≤ floor(lower(b))` (R-kernel)                                 |
+| `monotone_r`                  | `uhlc::id`    | Ord-match regression — guards the byte-lex Ord choice            |
+| `roundtrip_floor_nonpuncture` | `uhlc::id`    | `floor(lower(b)) == b` on the non-puncture region (b ≠ [0;16])   |
+
+### Spot checks
+
+- `uhlc::id::l_law_fails_at_puncture` — asserts `galois_l(l_view, a, b)`
+  returns `false` at the documented `(ID([0,…,0,1]), LX([0;16]))`
+  corner. Guards against a future ID-Ord change silently making the
+  L-law hold.
+- `uhlc::id::lower_total_at_puncture` — asserts
+  `HLIDLX16.lower(LX([0;16])).to_le_bytes() == [0,…,0,1]` (totality at
+  the boundary).
+
+### Kani proofs (gated on `cfg(kani)` + `features = "fixed,uhlc"`)
+
+- `ndur_u064::{galois_l, galois_r, iso_roundtrip_l, floor_le_ceil}`
+- `hlid_lx16::{galois_r, closure_r, kernel_r, monotone_r}`
+- `hlid_lx16::lower_never_panics` — totality over the full `[u8; 16]`
+  domain (no `kani::assume`).
+
+### Build gates
+
+```
+cargo build --no-default-features                            # uhlc off
+cargo build --features uhlc
+cargo test  --features uhlc
+cargo clippy --features uhlc --all-targets -- -D warnings
+RUSTDOCFLAGS=-D warnings cargo doc --features uhlc --no-deps
+```
+
+CI: add a `uhlc` cell in `.github/workflows/*.yml` mirroring `hifi`.
+
+### End-to-end scenario
+
+After implementation, this should compile and pass:
+
+```rust
+use connections::uhlc::{NDURU064, HLIDLX16};
+use connections::conn::{ConnL, ConnR};
+use connections::core::LX;
+use uhlc::{NTP64, ID};
+use core::num::NonZeroU128;
+
+// NDURU064 — full iso, both directions lossless.
+let t = NTP64(7_386_690_599_959_157_260);
+assert_eq!(NDURU064.ceil(t), 7_386_690_599_959_157_260_u64);
+assert_eq!(NDURU064.upper(NDURU064.ceil(t)), t);
+
+// HLIDLX16 — R-only Conn.
+let id = ID::from(NonZeroU128::new(0x33).unwrap());
+assert_eq!(HLIDLX16.floor(id).0, id.to_le_bytes());          // ID → bytes (lossless)
+assert_eq!(HLIDLX16.lower(HLIDLX16.floor(id)), id);          // round-trip via .lower()
+
+// Order-preservation: ID's derived Ord = LX<16>'s derived Ord, both byte-lex.
+let id_lo = ID::from(NonZeroU128::new(1).unwrap());
+let id_hi = ID::from(NonZeroU128::new(256).unwrap());
+assert!(id_lo > id_hi);                                       // ID byte-lex: [1,0..] > [0,1,0..]
+assert!(HLIDLX16.floor(id_lo) > HLIDLX16.floor(id_hi));
+
+// Puncture saturation — no panic, total function.
+let zero_lx: LX<16> = LX([0u8; 16]);
+let lex_min_id = HLIDLX16.lower(zero_lx);
+let mut expected = [0u8; 16];
+expected[15] = 1;
+assert_eq!(lex_min_id.to_le_bytes(), expected);              // saturates up to lex-min valid ID
+```
+
+## Reuse / pointers
+
+- `iso!` / `conn_k!` / `conn_l!` / `conn_r!` — `src/conn.rs:1110-1217`.
+  Macros require `expr` (fn names or closures) for forward/back/ceil/
+  inner/floor; pattern arms like `forward(t) = t.0` do **not** parse.
+- Law predicates — `src/prop/conn.rs` (`galois_l`, `galois_r`,
+  `closure_l/r`, `kernel_l/r`, `monotone_l/r`, `iso_roundtrip_l`,
+  `roundtrip_ceil`, `roundtrip_floor`, `floor_le_ceil`).
+- Closest structural template — `src/hifi.rs` (module rustdoc) +
+  `src/hifi/duration.rs` (single host-crate type with a couple of
+  Conns) + `src/kani/hifi_calendar.rs` (Kani harness layout).
+- NonZero arb pattern for Kani — `src/kani/nz_ext.rs:23-29`.
+
+## Deferred
+
+- `NTP64 ↔ core::time::Duration` Conn — `From<Duration>` panics for
+  `secs > u32::MAX`; needs saturating-ceil treatment.
+- `Timestamp` Conn — `(NTP64, ID)` lex-ordered composite; no single
+  integer endpoint without inventing a `u192`.
+- Cross-width pre-baking (`NDURU032`, `HLIDLX08`, …) — composable from
+  v1 Conns + existing `core::u064` / NonZero ladders.
+- `Extended<NTP64>` saturating endpoint — uhlc users typically don't
+  encounter the saturation boundary in practice.
+- Loosening `lib.rs:251` to allow `cargo kani` without `--features
+  fixed` — the outer gate currently bundles all Kani proofs together;
+  splitting them across feature axes is a refactor outside this sprint.
+
+## Review
+
+(Filled in at finalize time after T5 passes — `#[ignore]`d properties
+with re-enablement plans, design deviations, drift caught, recommendations.)

--- a/doc/reviews/review-00008.md
+++ b/doc/reviews/review-00008.md
@@ -1,0 +1,248 @@
+# PR #8 — uhlc Conns: NDURU064 + HLIDLX16
+
+## Summary
+
+Adds a feature-gated `src/uhlc/` module bridging the
+[`uhlc-rs`](https://crates.io/crates/uhlc) HLC types to existing
+endpoints via two Galois connections. Two consumers covered: the
+64-bit hybrid logical clock value `NTP64`, and the 16-byte node
+identifier `ID`.
+
+1. **`NDURU064` — `NTP64 ↔ u64`, iso (full triple).** `NTP64` is
+   `pub struct NTP64(pub u64)`, a transparent newtype with no
+   internal invariant. The forward / back pair is direct field
+   access; the iso laws hold trivially. Built via `iso!`.
+2. **`HLIDLX16` — `ID ↔ LX<16>`, right-Galois only.** `ID`'s derived
+   `Ord` is byte-lex from byte 0 of `to_le_bytes()` (LSB-first under
+   LE storage), which agrees with `LX<16>`'s lex-from-byte-0 `Ord`
+   but **disagrees** with the integer order on the underlying `u128`.
+   Bridging to `NonZero<u128>` or `LE<16>` would break Galois at any
+   pair where the LE byte order disagrees with the integer order
+   (`ID(1)` byte-lex-greater than `ID(256)` is the canonical
+   counter-example).
+   `LX<16>` is the right target type, *but* the iso is one value
+   short of total — `LX([0; 16])` is a byte string that no `ID`
+   represents (ID's construction enforces a non-zero `u128`). The
+   fix mirrors `nz_uint_ext!`'s shape: route the puncture to a
+   sentinel (here, `[0,…,0,1]` — the lex-min valid ID) and ship as a
+   single-sided Conn. R-Galois holds; L-Galois fails at the corner.
+   Built via `conn_r!`.
+
+### Galois-law derivation at the puncture
+
+At `b = LX([0; 16])` with `inner(b) = ID([0,…,0,1])`:
+
+- **R-law** (`inner(b) ≤ a ⟺ b ≤ floor(a)`): the LHS is
+  `ID([0,…,0,1]) ≤ a`, which holds for every valid `a` because
+  `ID([0,…,0,1])` is the lex-min `ID`. The RHS is `LX([0; 16]) ≤
+  LX(a.0)`, which holds for every valid `a` because `LX([0; 16])` is
+  the lex-min `LX<16>`. Both sides always true. ✓
+- **L-law** (`ceil(a) ≤ b ⟺ a ≤ inner(b)`): at the corner
+  `(a = ID([0,…,0,1]), b = LX([0; 16]))`, the LHS is
+  `LX(a.0) ≤ LX([0; 16])`, which is *false* (every valid `ID`'s
+  bytes are strictly above `[0; 16]` under lex). The RHS is
+  `a ≤ ID([0,…,0,1]) = a`, which is *true*. Mismatch. ✗
+
+So the structural choice is `conn_r!`, not `iso!`. Exact mirror of
+the `nz_uint_ext!` situation — the puncture sits on the *target*
+side rather than the source.
+
+### Totality and panics
+
+`HLIDLX16`'s endpoints are total — no `panic!`, no `.expect()`. The
+only fallible call (`ID::try_from(&[u8; 16])`) is fed bytes that are
+provably non-zero at every reachable call site: the puncture branch
+routes through a compile-time non-zero `LEX_MIN_ID_BYTES`, and the
+fallthrough branch only fires when `lx.0` has at least one non-zero
+byte. The `unreachable!()` arm documents the dead code statically.
+The Kani harness `lower_never_panics` exercises the full `[u8; 16]`
+domain with *no* `kani::assume` precondition, proving totality in
+the SMT sense.
+
+A documented L-law regression test (`l_law_fails_at_puncture`)
+builds an ad-hoc `Conn<ID, LX<16>>` from the same `(ceil, inner)`
+pair and asserts the L-law's documented `false`. If a future `ID`-Ord
+change ever silently makes the L-law hold, this test fails and forces
+a revisit of the `conn_r!` vs `iso!` choice.
+
+### Naming
+
+- **`NDUR`** (4L+0D) for `NTP64` — "NTP Duration", parallel to
+  `TDUR` (`time::Duration`) and `HDUR` (`hifitime::Duration`). The
+  `E***` family in `src/hifi/epoch.rs` is reserved for typed-epoch-
+  anchored types and would mislead here: `NTP64` is clock-agnostic
+  (`uhlc-rs/src/ntp64.rs:68-71`). Trailing digits on `NTP` collide
+  with NTP protocol version numbers (NTPv4, RFC 5905; v5 in draft),
+  so `NTP4`/`NTP5` are off-limits.
+- **`HLID`** (4L+0D) for `ID` — "HLC node ID". The name says what the
+  type *is*, parallel to the `NDUR` choice. `UHID` would have read as
+  a crate-prefix rather than a structural mnemonic.
+- **`U064`** (1L+3D) for `u64` — existing.
+- **`LX16`** (2L+2D) for `LX<16>` — wrapper family parallel to
+  `LE16`, `B216`, `L216`.
+
+Both Conn names (`NDURU064`, `HLIDLX16`) are exactly 8 chars, 4+4.
+No collisions in the codebase.
+
+### Files
+
+New:
+
+- `src/uhlc.rs` — module rustdoc + submodule declarations + `pub use`
+  re-exports.
+- `src/uhlc/ntp64.rs` — `NDURU064` + proptest battery + boundary spot
+  check.
+- `src/uhlc/id.rs` — `HLIDLX16` + proptest battery + negative
+  L-law assertion + totality spot check + floor/lower spot check.
+- `src/kani/uhlc.rs` — Kani harnesses for both Conns plus the
+  totality proof.
+
+Modified:
+
+- `Cargo.toml` — new optional `uhlc` dep (`default-features = false`
+  to skip uhlc's default `["std", "serde"]`, which would drag in
+  `humantime`, `lazy_static`, `log`, `rand/std`); new `uhlc` feature.
+- `src/lib.rs` — `#[cfg(feature = "uhlc")] pub mod uhlc;` alongside
+  `hifi`/`time`.
+- `src/kani.rs` — `#[cfg(feature = "uhlc")] mod uhlc;` alongside the
+  other feature-gated kani submodules.
+- `AGENTS.md` (= `CLAUDE.md`) — per-domain table gains `uhlc` and
+  `hifi` rows.
+- CI matrix (`ci.yml`, `pages.yml`, `kani.yml`), pre-push hook, and
+  `docs.rs` metadata — all add `uhlc` to their feature sets.
+
+### Why a single right-Galois target, not two
+
+The plan considered shipping both `Conn<ID, LX<16>, R>` and a
+literal-`nz_uint_ext!`-mirror `Conn<LX<16>, ID, L>`. They are
+algebraically equivalent (same `(ceil, inner) = (floor, lower)`
+swap), but `HLIDLX16` reads naturally as "domain-type encoded as
+bytes" — same order as `U128LE16`, `U064BE08`, etc. Shipping both
+would just double the public surface for one underlying construction.
+
+### Composition story
+
+Cross-width chains aren't pre-baked here. Users who need `NTP64 ↔
+u32` compose `NDURU064` with the existing `core::u064::U064U032`
+ladder; users who need `ID ↔ NonZeroU8`-style short keys compose
+`HLIDLX16` with manual byte projections (no canonical Conn fits, by
+design — `ID` is a 128-bit identifier; truncating it isn't a Galois
+connection, it's a hash). The `hifi` module pre-bakes a couple of
+common-precision rungs (`HDURNANO`, `HDURSECS`) for ergonomics, but
+there's no analogous "common precision" for HLC values — just the
+raw 64-bit timestamp.
+
+### Notable deferrals
+
+- `NTP64 ↔ core::time::Duration` — `From<Duration>` panics for
+  `secs > u32::MAX` (`uhlc-rs/src/ntp64.rs:287-293`); the proper
+  treatment is a saturating-ceil L-only Conn at the 32-bit-seconds
+  boundary. Not in v1 because no consumer has asked.
+- `Timestamp = (NTP64, ID)` — lex-ordered composite; no single
+  integer endpoint preserves the order without inventing a
+  `u192`. Users decompose: Conn over the `time` projection + Conn
+  over the `id` projection.
+- Loosening the `lib.rs:251` Kani gate so `cargo kani` doesn't
+  require `--features fixed` — a refactor across the existing Kani
+  module tree, outside this sprint. Today, `cargo kani --features
+  fixed,hifi,uhlc` exercises everything.
+
+### Verification
+
+- 14 in-module unit / proptest cases on top of the existing 689,
+  plus 44 doctests — all pass with
+  `cargo test --features fixed,time,hifi,uhlc,proptest,macros`.
+- `cargo build --no-default-features` and `cargo build --features
+  uhlc` both clean.
+- `cargo clippy --features fixed,time,hifi,uhlc,proptest,macros
+  --all-targets -- -D warnings` clean.
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features
+  fixed,proptest,macros,time,uhlc --document-private-items` clean.
+- Kani harnesses (10 total: 4 NDURU064 + 5 HLIDLX16 R-laws +
+  `lower_never_panics`) compile under `cargo kani --features
+  fixed,hifi,uhlc`; CI runs them weekly per the existing `kani.yml`
+  schedule, now with `--features fixed,hifi,uhlc`. (`fixed` is
+  required by the outer Kani gate at `lib.rs:251`; this PR's local
+  review caught a draft `kani.yml` that only enabled `hifi,uhlc`.)
+
+## Local review (2026-05-19)
+
+**Branch:** plan/2026-05-19-03
+**Commits:** 3 (origin/main..plan/2026-05-19-03)
+**Reviewer:** Codex (`codex review --base origin/main`)
+**Prompt fingerprint:** AGENTS.md=4563f590caa7dbba5ea9eae973fa59182f1a6470 calibration=missing
+
+---
+
+The runtime Conns and tests build, but the new Kani verification added by the patch is not exercised by the updated workflow because the required parent feature gate is not enabled.
+
+Review comment:
+
+- [P2] Enable the Kani parent gate for uhlc proofs — .github/workflows/kani.yml:22-22
+  With this workflow invocation, the new `src/kani/uhlc.rs` proofs are never compiled: the Kani module is only included under `#[cfg(all(kani, feature = "fixed"))]` in `src/lib.rs`, but CI now runs `cargo kani` with only `hifi,uhlc`. Add `fixed` here or relax the parent cfg; otherwise the advertised uhlc Kani coverage remains disabled.
+
+
+<!-- gh-id: 3271453893 -->
+### Copilot on [`src/uhlc.rs:9`](https://github.com/cmk/connections/pull/8#discussion_r3271453893) (2026-05-20 05:39 UTC)
+
+In this markdown table, `LX<16>` (and other generics with `<…>`) aren’t wrapped in code spans, so rustdoc/Markdown may treat `<16>` as an HTML tag and render it incorrectly or drop it. Wrap the endpoint types in backticks (e.g., `LX<16>`) or escape `<`/`>` to keep the table readable.
+
+
+<!-- gh-id: 4325471849 -->
+### copilot-pull-request-reviewer[bot] — COMMENTED ([2026-05-20 05:39 UTC](https://github.com/cmk/connections/pull/8#pullrequestreview-4325471849))
+
+## Pull request overview
+
+Adds a new `uhlc`-feature-gated module that bridges types from the external `uhlc` crate into this crate’s Conn ecosystem, providing lawful conversions for `NTP64` and `ID` via two Galois connections and wiring those into tests, Kani proofs, and CI/docs feature matrices.
+
+**Changes:**
+- Introduce `connections::uhlc` with `NDURU064` (`NTP64 ↔ u64` iso) and `HLIDLX16` (`ID ↔ LX<16>` right-Galois) plus property/unit tests.
+- Add Kani harnesses for both Conns and wire them into the feature-gated Kani module tree.
+- Add optional `uhlc` dependency + `uhlc` feature, and propagate `uhlc` through docs.rs metadata, CI workflows, and local hooks.
+
+### Reviewed changes
+
+Copilot reviewed 14 out of 14 changed files in this pull request and generated 2 comments.
+
+<details>
+<summary>Show a summary per file</summary>
+
+| File | Description |
+| ---- | ----------- |
+| `Cargo.toml` | Adds optional `uhlc` dependency, `uhlc` feature, and docs.rs feature set updates. |
+| `src/lib.rs` | Exposes `pub mod uhlc` behind `#[cfg(feature = "uhlc")]`. |
+| `src/uhlc.rs` | New module docs + submodule declarations and re-exports for the `uhlc` Conns. |
+| `src/uhlc/ntp64.rs` | Implements `NDURU064` iso (`NTP64 ↔ u64`) with proptests and boundary checks. |
+| `src/uhlc/id.rs` | Implements `HLIDLX16` right-Galois Conn (`ID ↔ LX<16>`) with puncture saturation + tests. |
+| `src/kani.rs` | Wires in the new `kani::uhlc` module behind `feature = "uhlc"`. |
+| `src/kani/uhlc.rs` | Adds Kani proofs for `NDURU064` and `HLIDLX16`, including totality proof for `lower`. |
+| `.github/workflows/ci.yml` | Runs tests/doctests with `uhlc` enabled in the feature set. |
+| `.github/workflows/pages.yml` | Builds docs with `uhlc` enabled for GitHub Pages artifacts. |
+| `.github/workflows/kani.yml` | Enables `fixed,hifi,uhlc` features so the new Kani proofs are compiled/exercised. |
+| `.githooks/pre-push` | Mirrors CI feature set by adding `uhlc` to local test/doc checks. |
+| `AGENTS.md` | Updates the per-domain Conn families table to include `uhlc` (and `hifi`). |
+| `doc/plans/plan-2026-05-19-03.md` | Adds a detailed implementation/verification plan for the `uhlc` module. |
+| `doc/reviews/review-00008.md` | Adds the PR’s review record/audit-trail entry. |
+</details>
+
+
+
+
+
+
+
+<!-- gh-id: 3271453928 -->
+### Copilot on [`doc/plans/plan-2026-05-19-03.md:68`](https://github.com/cmk/connections/pull/8#discussion_r3271453928) (2026-05-20 05:39 UTC)
+
+This task description no longer matches the implemented Kani harnesses: the committed `src/kani/uhlc.rs` doesn’t include `closure_l`/`closure_r` proofs for `NDURU064`, and it also omits the described `roundtrip_floor` / `lx16_to_id_never_panics` proof structure for `HLIDLX16`. Please update this section to reflect the actual proofs shipped (or add the missing proofs if the doc is the intended contract).
+
+
+<!-- gh-id: 3271559519 -->
+#### ↳ cmk ([2026-05-20 06:04 UTC](https://github.com/cmk/connections/pull/8#discussion_r3271559519))
+
+Fixed — wrapped `NTP64`, `u64`, `ID`, and `LX<16>` in code spans in the rustdoc table so `<16>` isn't parsed as an HTML tag.
+
+<!-- gh-id: 3271560262 -->
+#### ↳ cmk ([2026-05-20 06:04 UTC](https://github.com/cmk/connections/pull/8#discussion_r3271560262))
+
+Fixed — aligned the T4 narrative and the Kani sketch with the harnesses that actually shipped. `closure_l`/`closure_r` are dropped from NDURU064 (an iso's `iso_roundtrip_l` is the stronger form and subsumes both closures); `roundtrip_floor` is called out as proptest-only (`uhlc::id::tests::roundtrip_floor_nonpuncture`) and not duplicated as a Kani harness; and the totality proof reads as `lower_never_panics` (the shipped name) rather than the draft `lx16_to_id_never_panics`. Also dropped the stale `kani::assume(bytes != [0u8; 16])` from the `kernel_r` sketch — the R-kernel law holds at the puncture too, which the shipped harness exercises without an assume.

--- a/src/kani.rs
+++ b/src/kani.rs
@@ -90,6 +90,8 @@ mod nz_ext;
 mod time_pure;
 #[cfg(feature = "time")]
 mod time_walk;
+#[cfg(feature = "uhlc")]
+mod uhlc;
 mod uint_narrow;
 mod uint_sat;
 mod uint_widen;

--- a/src/kani/uhlc.rs
+++ b/src/kani/uhlc.rs
@@ -1,0 +1,91 @@
+//! Kani harnesses for [`crate::uhlc::NDURU064`] (iso) and
+//! [`crate::uhlc::HLIDLX16`] (right-Galois). NDURU064 gets the
+//! standard iso battery; HLIDLX16 gets the R-only battery plus a
+//! totality proof (`lower_never_panics`) that exercises
+//! `kani::any::<[u8; 16]>()` with **no precondition** — CBMC bit-
+//! blasts over the full domain and verifies the function returns
+//! a value (the lex-min ID) on the all-zero puncture without
+//! `unreachable!()` or `panic!()` firing.
+
+use crate::conn::{ConnL, ConnR};
+use crate::core::LX;
+use crate::prop::conn as conn_laws;
+use crate::uhlc::{HLIDLX16, NDURU064};
+use core::num::NonZeroU128;
+use uhlc::{ID, NTP64};
+
+fn arb_id_symbolic() -> ID {
+    let n: u128 = kani::any();
+    kani::assume(n != 0);
+    ID::from(NonZeroU128::new(n).unwrap())
+}
+
+mod ndur_u064 {
+    use super::*;
+
+    #[kani::proof]
+    fn galois_l() {
+        let t = NTP64(kani::any());
+        let n: u64 = kani::any();
+        assert!(conn_laws::galois_l(&NDURU064.conn_l(), t, n));
+    }
+
+    #[kani::proof]
+    fn galois_r() {
+        let t = NTP64(kani::any());
+        let n: u64 = kani::any();
+        assert!(conn_laws::galois_r(&NDURU064.conn_r(), t, n));
+    }
+
+    #[kani::proof]
+    fn iso_roundtrip_l() {
+        let t = NTP64(kani::any());
+        assert!(conn_laws::iso_roundtrip_l(&NDURU064.conn_l(), t));
+    }
+
+    #[kani::proof]
+    fn floor_le_ceil() {
+        let t = NTP64(kani::any());
+        assert!(conn_laws::floor_le_ceil(&NDURU064, t));
+    }
+}
+
+mod hlid_lx16 {
+    use super::*;
+
+    #[kani::proof]
+    fn galois_r() {
+        let a = arb_id_symbolic();
+        let bytes: [u8; 16] = kani::any();
+        assert!(conn_laws::galois_r(&HLIDLX16, a, LX(bytes)));
+    }
+
+    #[kani::proof]
+    fn closure_r() {
+        let a = arb_id_symbolic();
+        assert!(conn_laws::closure_r(&HLIDLX16, a));
+    }
+
+    #[kani::proof]
+    fn kernel_r() {
+        let bytes: [u8; 16] = kani::any();
+        assert!(conn_laws::kernel_r(&HLIDLX16, LX(bytes)));
+    }
+
+    #[kani::proof]
+    fn monotone_r() {
+        let b1: [u8; 16] = kani::any();
+        let b2: [u8; 16] = kani::any();
+        assert!(conn_laws::monotone_r(&HLIDLX16, LX(b1), LX(b2)));
+    }
+
+    /// **Totality.** No `kani::assume` precondition — the full
+    /// `[u8; 16]` domain, including the all-zero puncture, must
+    /// produce a value (the lex-min ID at the puncture) without
+    /// `unreachable!()` or `panic!()` firing.
+    #[kani::proof]
+    fn lower_never_panics() {
+        let bytes: [u8; 16] = kani::any();
+        let _ = HLIDLX16.lower(LX(bytes));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,9 @@ pub mod lattice;
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 #[cfg(feature = "time")]
 pub mod time;
+#[cfg_attr(docsrs, doc(cfg(feature = "uhlc")))]
+#[cfg(feature = "uhlc")]
+pub mod uhlc;
 
 /// Idiomatic batch import of the trait family, two-sided helpers, and
 /// the [`Interval`](crate::interval::Interval) bracket type.

--- a/src/uhlc.rs
+++ b/src/uhlc.rs
@@ -1,0 +1,24 @@
+//! # uhlc Conns
+//!
+//! Galois connections bridging the [`uhlc`](https://docs.rs/uhlc) crate's
+//! HLC types to integer / byte endpoints. Gated on `feature = "uhlc"`.
+//!
+//! | Conn         | Endpoints           | Law        |
+//! |--------------|---------------------|------------|
+//! | `NDURU064`   | `NTP64` ↔ `u64`     | iso (full) |
+//! | `HLIDLX16`   | `ID` ↔ `LX<16>`     | R-only     |
+//!
+//! `HLIDLX16` bridges to the opaque-bytes [`LX<16>`](crate::core::LX)
+//! rather than `NonZero<u128>`: `ID`'s derived `Ord` is byte-lex
+//! (LSB-first under LE storage), which is *not* the integer order on
+//! the underlying `u128`. `LX<16>`'s lex-from-byte-0 `Ord` matches
+//! `ID`'s. The connection is right-Galois (not iso): `LX<16>` has the
+//! all-zero value that `ID` doesn't, and saturating that puncture to
+//! the lex-min valid `ID` breaks the L-law but preserves the R-law.
+//! See the [`id`] submodule for the derivation.
+
+pub mod id;
+pub mod ntp64;
+
+pub use id::HLIDLX16;
+pub use ntp64::NDURU064;

--- a/src/uhlc/id.rs
+++ b/src/uhlc/id.rs
@@ -1,0 +1,159 @@
+//! `Conn<ID, LX<16>, R>` — right-Galois only. `ID` is a 16-byte
+//! LE-stored token whose derived `Ord` is byte-lex from byte 0 of
+//! `to_le_bytes()` (i.e., **LSB-first** under LE storage);
+//! [`LX<16>`](crate::core::LX) is the identity byte-wrapper with the
+//! same derived `Ord`. `LX<16>` carries one value (`LX([0; 16])`)
+//! that no `ID` represents — `ID`'s construction enforces a non-zero
+//! `u128` invariant (`uhlc-rs/src/id.rs:127-129`).
+//!
+//! The connection is total-via-saturation: the puncture maps to the
+//! lex-min valid `ID` (the byte array `[0,…,0,1]`, equal to
+//! `NonZeroU128::new(1 << 120).unwrap()`). L-Galois fails at that
+//! boundary; R-Galois holds, so this is a `conn_r!` rather than an
+//! `iso!`. See the plan-2026-05-19-03 derivation for the worked
+//! corner case.
+//!
+//! **No panics on reachable inputs.** `ID::try_from(&[u8; 16])`
+//! errors only on the all-zero array, which the puncture branch
+//! avoids by routing to `LEX_MIN_ID_BYTES`; the `unreachable!()`
+//! arm is dead code at every reachable call site, and the Kani
+//! `lower_never_panics` harness in `src/kani/uhlc.rs` proves
+//! totality over the full `[u8; 16]` domain.
+
+use uhlc::ID;
+
+use crate::core::LX;
+
+/// Lex-min valid `ID` under the byte-lex-from-byte-0 Ord — byte 15
+/// = 1, all other bytes 0. Numerically this is `1 << 120`, but
+/// under `ID`'s derived `Ord` it is the minimum.
+const LEX_MIN_ID_BYTES: [u8; 16] = {
+    let mut b = [0u8; 16];
+    b[15] = 1;
+    b
+};
+
+fn id_to_lx16(id: ID) -> LX<16> {
+    LX(id.to_le_bytes())
+}
+
+fn lx16_to_id(lx: LX<16>) -> ID {
+    let bytes: &[u8; 16] = if lx.0 == [0u8; 16] {
+        &LEX_MIN_ID_BYTES
+    } else {
+        &lx.0
+    };
+    ID::try_from(bytes).unwrap_or_else(|_| unreachable!())
+}
+
+crate::conn_r! {
+    /// `Conn<ID, LX<16>, R>` — `ID`'s 16-byte representation with
+    /// saturating decode at the all-zero byte string.
+    ///
+    /// - `.floor(id)` (lossless): `id` → its LE-bytes-as-`LX<16>`.
+    /// - `.lower(lx)` (saturating): valid bytes round-trip; the
+    ///   single all-zero `LX([0; 16])` value saturates *up* to the
+    ///   lex-min valid `ID`. R-Galois holds at this boundary;
+    ///   L-Galois does not — that's why this is a `conn_r!`, not
+    ///   an `iso!`.
+    pub HLIDLX16 : ID => LX<16> {
+        inner: lx16_to_id,
+        floor: id_to_lx16,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prop::conn as conn_laws;
+    use core::num::NonZeroU128;
+    use proptest::prelude::*;
+
+    // `ID` doesn't derive `Debug`, so proptest strategies can't
+    // yield `ID` directly. Generate non-zero `u128` and construct
+    // `ID` in the body.
+
+    fn arb_lx16() -> impl Strategy<Value = LX<16>> {
+        prop_oneof![
+            Just(LX([0u8; 16])),
+            Just(LX([0xFFu8; 16])),
+            any::<[u8; 16]>().prop_map(LX),
+        ]
+    }
+
+    fn arb_nonpuncture_lx16() -> impl Strategy<Value = LX<16>> {
+        any::<[u8; 16]>()
+            .prop_filter("non-zero bytes", |b| *b != [0u8; 16])
+            .prop_map(LX)
+    }
+
+    fn arb_nz_u128() -> impl Strategy<Value = NonZeroU128> {
+        prop_oneof![
+            Just(NonZeroU128::new(1).unwrap()),
+            Just(NonZeroU128::MAX),
+            any::<u128>().prop_filter_map("non-zero u128", NonZeroU128::new),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn galois_r(a in arb_nz_u128(), b in arb_lx16()) {
+            let id = ID::from(a);
+            prop_assert!(conn_laws::galois_r(&HLIDLX16, id, b));
+        }
+        #[test]
+        fn closure_r(a in arb_nz_u128()) {
+            let id = ID::from(a);
+            prop_assert!(conn_laws::closure_r(&HLIDLX16, id));
+        }
+        #[test]
+        fn kernel_r(b in arb_lx16()) {
+            prop_assert!(conn_laws::kernel_r(&HLIDLX16, b));
+        }
+        #[test]
+        fn monotone_r(b1 in arb_lx16(), b2 in arb_lx16()) {
+            prop_assert!(conn_laws::monotone_r(&HLIDLX16, b1, b2));
+        }
+        #[test]
+        fn roundtrip_floor_nonpuncture(b in arb_nonpuncture_lx16()) {
+            // floor(lower(b)) == b on non-puncture inputs.
+            prop_assert_eq!(HLIDLX16.floor(HLIDLX16.lower(b)).0, b.0);
+        }
+    }
+
+    /// The connection is R-only; this builds an ad-hoc L-Conn from
+    /// the same `(ceil, inner)` pair and asserts the L-Galois law
+    /// **fails** at the documented puncture corner. If a future
+    /// `ID`-Ord change silently makes the L-law hold, this test
+    /// will fail and force a revisit of the R-only choice.
+    #[test]
+    fn l_law_fails_at_puncture() {
+        let l: crate::conn::Conn<ID, LX<16>> = crate::conn::Conn::new_l(id_to_lx16, lx16_to_id);
+        let a = ID::try_from(&LEX_MIN_ID_BYTES).unwrap();
+        let b = LX([0u8; 16]);
+        // ceil(a) = LX([0,...,0,1]) > LX([0;16]) (lex), so LHS false.
+        // inner(b) = a, so a ≤ inner(b) is true.
+        assert!(!conn_laws::galois_l(&l, a, b));
+    }
+
+    /// Totality at the puncture — the saturating decode lands on
+    /// the lex-min valid `ID`, no panic.
+    #[test]
+    fn lower_total_at_puncture() {
+        let z = LX([0u8; 16]);
+        let id = HLIDLX16.lower(z);
+        let mut expected = [0u8; 16];
+        expected[15] = 1;
+        assert_eq!(id.to_le_bytes(), expected);
+    }
+
+    /// Floor is lossless; round-trip via `.lower()` returns the
+    /// original `ID` for every non-puncture byte string (which is
+    /// every byte string that came from a real `ID`).
+    #[test]
+    fn floor_lower_roundtrip_spot() {
+        let id = ID::from(NonZeroU128::new(0x12345678).unwrap());
+        let lx = HLIDLX16.floor(id);
+        assert_eq!(HLIDLX16.lower(lx).to_le_bytes(), id.to_le_bytes());
+    }
+}

--- a/src/uhlc/ntp64.rs
+++ b/src/uhlc/ntp64.rs
@@ -1,0 +1,69 @@
+//! `NTP64 ↔ u64` iso. `NTP64` is a transparent newtype with no
+//! internal invariant (`uhlc-rs/src/ntp64.rs:75`: `pub struct
+//! NTP64(pub u64)`), so the forward/back pair is direct field
+//! access and the iso laws hold trivially.
+
+use uhlc::NTP64;
+
+const fn ntp64_to_u64(t: NTP64) -> u64 {
+    t.0
+}
+const fn u64_to_ntp64(n: u64) -> NTP64 {
+    NTP64(n)
+}
+
+crate::iso! {
+    /// `NTP64 ↔ u64` — lossless iso over the transparent newtype.
+    pub NDURU064 : NTP64 => u64 {
+        forward: ntp64_to_u64,
+        back:    u64_to_ntp64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conn::{ConnL, ConnR};
+    use crate::prop::conn as conn_laws;
+    use proptest::prelude::*;
+
+    // `NTP64` doesn't derive `Debug`, so proptest strategies can't
+    // yield `NTP64` directly (shrink display would fail to print).
+    // Generate a `u64` and construct `NTP64` in the body instead.
+
+    proptest! {
+        #[test]
+        fn iso_roundtrip_l(n in any::<u64>()) {
+            let t = NTP64(n);
+            prop_assert!(conn_laws::iso_roundtrip_l(&NDURU064.conn_l(), t));
+        }
+        #[test]
+        fn roundtrip_ceil(n in any::<u64>()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&NDURU064.conn_l(), n));
+        }
+        #[test]
+        fn galois_l(n in any::<u64>(), m in any::<u64>()) {
+            let t = NTP64(n);
+            prop_assert!(conn_laws::galois_l(&NDURU064.conn_l(), t, m));
+        }
+        #[test]
+        fn galois_r(n in any::<u64>(), m in any::<u64>()) {
+            let t = NTP64(n);
+            prop_assert!(conn_laws::galois_r(&NDURU064.conn_r(), t, m));
+        }
+        #[test]
+        fn floor_le_ceil(n in any::<u64>()) {
+            let t = NTP64(n);
+            prop_assert!(conn_laws::floor_le_ceil(&NDURU064, t));
+        }
+    }
+
+    #[test]
+    fn boundary_values() {
+        // The two corners of the u64 range round-trip losslessly.
+        assert_eq!(NDURU064.ceil(NTP64(0)), 0);
+        assert_eq!(NDURU064.upper(0), NTP64(0));
+        assert_eq!(NDURU064.ceil(NTP64(u64::MAX)), u64::MAX);
+        assert_eq!(NDURU064.upper(u64::MAX), NTP64(u64::MAX));
+    }
+}


### PR DESCRIPTION
Adds a feature-gated `src/uhlc/` module bridging the
[`uhlc-rs`](https://crates.io/crates/uhlc) HLC types to existing
endpoints via two Galois connections. Two consumers covered: the
64-bit hybrid logical clock value `NTP64`, and the 16-byte node
identifier `ID`.

1. **`NDURU064` — `NTP64 ↔ u64`, iso (full triple).** `NTP64` is
   `pub struct NTP64(pub u64)`, a transparent newtype with no
   internal invariant. The forward / back pair is direct field
   access; the iso laws hold trivially. Built via `iso!`.
2. **`HLIDLX16` — `ID ↔ LX<16>`, right-Galois only.** `ID`'s derived
   `Ord` is byte-lex from byte 0 of `to_le_bytes()` (LSB-first under
   LE storage), which agrees with `LX<16>`'s lex-from-byte-0 `Ord`
   but **disagrees** with the integer order on the underlying `u128`.
   Bridging to `NonZero<u128>` or `LE<16>` would break Galois at any
   pair where the LE byte order disagrees with the integer order
   (`ID(1)` byte-lex-greater than `ID(256)` is the canonical
   counter-example).
   `LX<16>` is the right target type, *but* the iso is one value
   short of total — `LX([0; 16])` is a byte string that no `ID`
   represents (ID's construction enforces a non-zero `u128`). The
   fix mirrors `nz_uint_ext!`'s shape: route the puncture to a
   sentinel (here, `[0,…,0,1]` — the lex-min valid ID) and ship as a
   single-sided Conn. R-Galois holds; L-Galois fails at the corner.
   Built via `conn_r!`.

### Galois-law derivation at the puncture

At `b = LX([0; 16])` with `inner(b) = ID([0,…,0,1])`:

- **R-law** (`inner(b) ≤ a ⟺ b ≤ floor(a)`): the LHS is
  `ID([0,…,0,1]) ≤ a`, which holds for every valid `a` because
  `ID([0,…,0,1])` is the lex-min `ID`. The RHS is `LX([0; 16]) ≤
  LX(a.0)`, which holds for every valid `a` because `LX([0; 16])` is
  the lex-min `LX<16>`. Both sides always true. ✓
- **L-law** (`ceil(a) ≤ b ⟺ a ≤ inner(b)`): at the corner
  `(a = ID([0,…,0,1]), b = LX([0; 16]))`, the LHS is
  `LX(a.0) ≤ LX([0; 16])`, which is *false* (every valid `ID`'s
  bytes are strictly above `[0; 16]` under lex). The RHS is
  `a ≤ ID([0,…,0,1]) = a`, which is *true*. Mismatch. ✗

So the structural choice is `conn_r!`, not `iso!`. Exact mirror of
the `nz_uint_ext!` situation — the puncture sits on the *target*
side rather than the source.

### Totality and panics

`HLIDLX16`'s endpoints are total — no `panic!`, no `.expect()`. The
only fallible call (`ID::try_from(&[u8; 16])`) is fed bytes that are
provably non-zero at every reachable call site: the puncture branch
routes through a compile-time non-zero `LEX_MIN_ID_BYTES`, and the
fallthrough branch only fires when `lx.0` has at least one non-zero
byte. The `unreachable!()` arm documents the dead code statically.
The Kani harness `lower_never_panics` exercises the full `[u8; 16]`
domain with *no* `kani::assume` precondition, proving totality in
the SMT sense.

A documented L-law regression test (`l_law_fails_at_puncture`)
builds an ad-hoc `Conn<ID, LX<16>>` from the same `(ceil, inner)`
pair and asserts the L-law's documented `false`. If a future `ID`-Ord
change ever silently makes the L-law hold, this test fails and forces
a revisit of the `conn_r!` vs `iso!` choice.

### Naming

- **`NDUR`** (4L+0D) for `NTP64` — "NTP Duration", parallel to
  `TDUR` (`time::Duration`) and `HDUR` (`hifitime::Duration`). The
  `E***` family in `src/hifi/epoch.rs` is reserved for typed-epoch-
  anchored types and would mislead here: `NTP64` is clock-agnostic
  (`uhlc-rs/src/ntp64.rs:68-71`). Trailing digits on `NTP` collide
  with NTP protocol version numbers (NTPv4, RFC 5905; v5 in draft),
  so `NTP4`/`NTP5` are off-limits.
- **`HLID`** (4L+0D) for `ID` — "HLC node ID". The name says what the
  type *is*, parallel to the `NDUR` choice. `UHID` would have read as
  a crate-prefix rather than a structural mnemonic.
- **`U064`** (1L+3D) for `u64` — existing.
- **`LX16`** (2L+2D) for `LX<16>` — wrapper family parallel to
  `LE16`, `B216`, `L216`.

Both Conn names (`NDURU064`, `HLIDLX16`) are exactly 8 chars, 4+4.
No collisions in the codebase.

### Files

New:

- `src/uhlc.rs` — module rustdoc + submodule declarations + `pub use`
  re-exports.
- `src/uhlc/ntp64.rs` — `NDURU064` + proptest battery + boundary spot
  check.
- `src/uhlc/id.rs` — `HLIDLX16` + proptest battery + negative
  L-law assertion + totality spot check + floor/lower spot check.
- `src/kani/uhlc.rs` — Kani harnesses for both Conns plus the
  totality proof.

Modified:

- `Cargo.toml` — new optional `uhlc` dep (`default-features = false`
  to skip uhlc's default `["std", "serde"]`, which would drag in
  `humantime`, `lazy_static`, `log`, `rand/std`); new `uhlc` feature.
- `src/lib.rs` — `#[cfg(feature = "uhlc")] pub mod uhlc;` alongside
  `hifi`/`time`.
- `src/kani.rs` — `#[cfg(feature = "uhlc")] mod uhlc;` alongside the
  other feature-gated kani submodules.
- `AGENTS.md` (= `CLAUDE.md`) — per-domain table gains `uhlc` and
  `hifi` rows.
- CI matrix (`ci.yml`, `pages.yml`, `kani.yml`), pre-push hook, and
  `docs.rs` metadata — all add `uhlc` to their feature sets.

### Why a single right-Galois target, not two

The plan considered shipping both `Conn<ID, LX<16>, R>` and a
literal-`nz_uint_ext!`-mirror `Conn<LX<16>, ID, L>`. They are
algebraically equivalent (same `(ceil, inner) = (floor, lower)`
swap), but `HLIDLX16` reads naturally as "domain-type encoded as
bytes" — same order as `U128LE16`, `U064BE08`, etc. Shipping both
would just double the public surface for one underlying construction.

### Composition story

Cross-width chains aren't pre-baked here. Users who need `NTP64 ↔
u32` compose `NDURU064` with the existing `core::u064::U064U032`
ladder; users who need `ID ↔ NonZeroU8`-style short keys compose
`HLIDLX16` with manual byte projections (no canonical Conn fits, by
design — `ID` is a 128-bit identifier; truncating it isn't a Galois
connection, it's a hash). The `hifi` module pre-bakes a couple of
common-precision rungs (`HDURNANO`, `HDURSECS`) for ergonomics, but
there's no analogous "common precision" for HLC values — just the
raw 64-bit timestamp.

### Notable deferrals

- `NTP64 ↔ core::time::Duration` — `From<Duration>` panics for
  `secs > u32::MAX` (`uhlc-rs/src/ntp64.rs:287-293`); the proper
  treatment is a saturating-ceil L-only Conn at the 32-bit-seconds
  boundary. Not in v1 because no consumer has asked.
- `Timestamp = (NTP64, ID)` — lex-ordered composite; no single
  integer endpoint preserves the order without inventing a
  `u192`. Users decompose: Conn over the `time` projection + Conn
  over the `id` projection.
- Loosening the `lib.rs:251` Kani gate so `cargo kani` doesn't
  require `--features fixed` — a refactor across the existing Kani
  module tree, outside this sprint. Today, `cargo kani --features
  fixed,hifi,uhlc` exercises everything.

### Verification

- 14 in-module unit / proptest cases on top of the existing 689,
  plus 44 doctests — all pass with
  `cargo test --features fixed,time,hifi,uhlc,proptest,macros`.
- `cargo build --no-default-features` and `cargo build --features
  uhlc` both clean.
- `cargo clippy --features fixed,time,hifi,uhlc,proptest,macros
  --all-targets -- -D warnings` clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features
  fixed,proptest,macros,time,uhlc --document-private-items` clean.
- Kani harnesses (10 total: 4 NDURU064 + 5 HLIDLX16 R-laws +
  `lower_never_panics`) compile under `cargo kani --features
  fixed,hifi,uhlc`; CI runs them weekly per the existing `kani.yml`
  schedule, now with `--features fixed,hifi,uhlc`. (`fixed` is
  required by the outer Kani gate at `lib.rs:251`; this PR's local
  review caught a draft `kani.yml` that only enabled `hifi,uhlc`.)
