### PR TITLE
feat: Expand time feature surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,15 @@ fixed = { version = "1", optional = true }
 # assertion that our proptest strategies (arb_extended_offset_dt et al.) trip
 # on. Floating this back to "0.3" is a follow-up after clamping the date /
 # offset generators so normalized UTC dates stay in range.
-time = { version = ">=0.3, <0.3.46", optional = true }
+time = { version = ">=0.3, <0.3.46", optional = true, default-features = false }
 hifitime = { version = "4.3", optional = true, default-features = false }
 proptest = { version = "1", optional = true }
 uhlc = { version = "0.9", optional = true, default-features = false }
 
 [dev-dependencies]
 proptest = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 trybuild = "1"
 
 [features]
@@ -69,10 +71,18 @@ fixed = ["dep:fixed"]
 proptest = ["dep:proptest"]
 
 # Enable civil-calendar and time-span Conns backed by the `time` crate
-# under `connections::time::*`. This is opt-in because the crate's
-# core algebra, numeric, fixed-point, char, addr, and std::time
-# strategy surfaces do not need the external dependency.
-time = ["dep:time"]
+# under `connections::time::*`, plus the upstream time types and
+# RFC3339 serde adapters used by downstream host crates. This is
+# opt-in because the crate's core algebra, numeric, fixed-point, char,
+# addr, and std::time strategy surfaces do not need the external
+# dependency.
+time = [
+    "dep:time",
+    "time/std",
+    "time/serde-well-known",
+    "time/parsing",
+    "time/formatting",
+]
 
 # Enable IEEE binary16 (`f16`) support: `F016`, `F032F016`, `F064F016`,
 # the f16-specific ULP machinery, and the `arb_f16` /

--- a/tests/time_feature_surface.rs
+++ b/tests/time_feature_surface.rs
@@ -1,0 +1,35 @@
+#![cfg(feature = "time")]
+#![forbid(unsafe_code)]
+
+use connections::time::{ODTMSECS, SDURU064};
+use serde::{Deserialize, Serialize};
+use time::serde::rfc3339;
+use time::{Duration, OffsetDateTime};
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct Timestamped {
+    #[serde(with = "rfc3339")]
+    at: OffsetDateTime,
+    #[serde(with = "rfc3339::option")]
+    maybe_at: Option<OffsetDateTime>,
+}
+
+#[test]
+fn time_feature_enables_upstream_time_surface() {
+    let _ = ODTMSECS;
+    let _ = SDURU064;
+
+    let now: OffsetDateTime = OffsetDateTime::now_utc();
+    assert!(now + Duration::seconds(1) > now);
+
+    let value = Timestamped {
+        at: OffsetDateTime::UNIX_EPOCH,
+        maybe_at: Some(OffsetDateTime::UNIX_EPOCH + Duration::seconds(1)),
+    };
+
+    let encoded = serde_json::to_string(&value).expect("RFC3339 serialization should succeed");
+    let decoded: Timestamped =
+        serde_json::from_str(&encoded).expect("RFC3339 deserialization should succeed");
+
+    assert_eq!(decoded, value);
+}


### PR DESCRIPTION
## Summary

Enable the upstream `time` crate features required by downstream users when `connections/time` is enabled:

- `std` for APIs such as `OffsetDateTime::now_utc`
- `serde-well-known`, `parsing`, and `formatting` for RFC3339 serde adapters

This keeps the library's existing public surface style: `connections::time` continues to flatten Conn constants only, while downstream crates import `time::{Duration, OffsetDateTime}` and `time::serde::rfc3339` from their direct `time` dependency.

## Validation

- `cargo test --features time --test time_feature_surface`
- `cargo check --features time`
- `cargo clippy --all-targets --features time -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features time`
- pre-push hook: `cargo test --quiet`, `cargo clippy --all-targets --quiet -- -D warnings`, `cargo doc --no-deps --features fixed,proptest,macros,time,uhlc --document-private-items`
- scratch crate depending on `connections` with `features = ["time"]` and direct `time` with `default-features = false` compiled `OffsetDateTime::now_utc()` and `time::serde::rfc3339`
