### PR TITLE
build: Update time and uhlc dependency bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,10 @@ exclude = [
 
 [dependencies]
 fixed = { version = "1", optional = true }
-# Upper-bounded to <0.3.46 because 0.3.46 added a stricter `year >= -9999`
-# assertion that our proptest strategies (arb_extended_offset_dt et al.) trip
-# on. Floating this back to "0.3" is a follow-up after clamping the date /
-# offset generators so normalized UTC dates stay in range.
-time = { version = ">=0.3, <0.3.46", optional = true }
+time = { version = ">=0.3.47, <0.4", optional = true, default-features = false }
 hifitime = { version = "4.3", optional = true, default-features = false }
 proptest = { version = "1", optional = true }
-uhlc = { version = "0.9", optional = true, default-features = false }
+uhlc = { version = ">=0.9.0, <0.10", optional = true, default-features = false }
 
 [dev-dependencies]
 proptest = "1"
@@ -69,9 +65,10 @@ fixed = ["dep:fixed"]
 proptest = ["dep:proptest"]
 
 # Enable civil-calendar and time-span Conns backed by the `time` crate
-# under `connections::time::*`. This is opt-in because the crate's
-# core algebra, numeric, fixed-point, char, addr, and std::time
-# strategy surfaces do not need the external dependency.
+# under `connections::time::*`. Host crates own their own `time`
+# feature policy (`std`, parsing/formatting, serde adapters, local
+# offset support, etc.); this feature only enables the optional
+# dependency needed to compile the Conn surface.
 time = ["dep:time"]
 
 # Enable IEEE binary16 (`f16`) support: `F016`, `F032F016`, `F064F016`,

--- a/deny.toml
+++ b/deny.toml
@@ -7,19 +7,7 @@
 # dependency graph. Yanked crates are a warning (sometimes unavoidable
 # transitively) rather than an error.
 yanked = "warn"
-ignore = [
-    # RUSTSEC-2026-0009 — `time` < 0.3.47 DoS via stack exhaustion in
-    # the RFC-2822 parser. We're pinned to `time = ">=0.3, <0.3.46"`
-    # to avoid 0.3.46's stricter `year >= -9999` assertion that our
-    # `arb_offset_dt` proptest strategy trips on at the Date::MIN
-    # boundary with a non-zero UTC offset. Connections does not call
-    # any RFC-2822 parser path (no `parse(Rfc2822)`, no
-    # `OffsetDateTime::parse(_, &Rfc2822)`), so the attack surface
-    # is zero for our usage. Drop this entry after clamping
-    # `arb_date()`'s year range so we can float `time = "0.3"` and
-    # adopt the fix that landed in 0.3.47.
-    "RUSTSEC-2026-0009",
-]
+ignore = []
 
 [bans]
 # Multiple versions of the same crate usually indicate a dependency

--- a/src/prop/arb.rs
+++ b/src/prop/arb.rs
@@ -775,34 +775,48 @@ pub fn arb_extended_utc_offset() -> impl Strategy<Value = Extended<UtcOffset>> {
     ]
 }
 
-/// Arbitrary `time::OffsetDateTime`. Cartesian product of
-/// `(arb_date, arb_time, arb_utc_offset)` plus the canonical
-/// landmarks: `UNIX_EPOCH`, the type-level extremes, ±1 ns from
-/// epoch, and the Y2038 cutover.
+/// Arbitrary `time::OffsetDateTime` over an order-safe subdomain.
+/// Generated from representable instants first, with all samples held
+/// two days inside the UTC instant range. That keeps construction and
+/// `time`'s offset-rebasing `Ord` implementation from normalizing
+/// either side of a comparison outside the valid UTC year range.
 #[cfg(feature = "time")]
 pub fn arb_offset_dt() -> impl Strategy<Value = OffsetDateTime> {
     let y2038 =
         OffsetDateTime::from_unix_timestamp(2_147_483_648).expect("Y2038 in OffsetDateTime range");
+    let min_ns = OffsetDateTime::new_in_offset(Date::MIN, Time::MIDNIGHT, UtcOffset::UTC)
+        .unix_timestamp_nanos();
+    let max_ns = OffsetDateTime::new_in_offset(
+        Date::MAX,
+        Time::from_hms_nano(23, 59, 59, 999_999_999).expect("end-of-day"),
+        UtcOffset::UTC,
+    )
+    .unix_timestamp_nanos();
+    let order_margin_ns = 2_i128 * 24 * 60 * 60 * 1_000_000_000;
+    let safe_min_ns = min_ns + order_margin_ns;
+    let safe_max_ns = max_ns - order_margin_ns;
     let landmarks = prop_oneof![
         1 => Just(OffsetDateTime::UNIX_EPOCH),
         1 => Just(OffsetDateTime::from_unix_timestamp_nanos(1).expect("epoch + 1ns")),
         1 => Just(OffsetDateTime::from_unix_timestamp_nanos(-1).expect("epoch - 1ns")),
         1 => Just(y2038),
     ];
-    let extremes = prop_oneof![
-        1 => Just(OffsetDateTime::new_in_offset(Date::MIN, Time::MIDNIGHT, UtcOffset::UTC)),
-        1 => Just(OffsetDateTime::new_in_offset(
-            Date::MAX,
-            Time::from_hms_nano(23, 59, 59, 999_999_999).expect("end-of-day"),
-            UtcOffset::UTC,
-        )),
+    let safe_extremes = prop_oneof![
+        1 => Just(OffsetDateTime::from_unix_timestamp_nanos(safe_min_ns).expect("safe min")),
+        1 => Just(OffsetDateTime::from_unix_timestamp_nanos(safe_max_ns).expect("safe max")),
     ];
-    let body = (arb_date(), arb_time(), arb_utc_offset())
-        .prop_map(|(d, t, o)| OffsetDateTime::new_in_offset(d, t, o));
+    let utc_body = (safe_min_ns..=safe_max_ns)
+        .prop_map(|ns| OffsetDateTime::from_unix_timestamp_nanos(ns).expect("safe nanos"));
+    let offset_body = ((safe_min_ns)..=(safe_max_ns), arb_utc_offset()).prop_map(|(ns, offset)| {
+        OffsetDateTime::from_unix_timestamp_nanos(ns)
+            .expect("safe nanos")
+            .to_offset(offset)
+    });
     prop_oneof![
         2 => landmarks,
-        1 => extremes,
-        9 => body,
+        1 => safe_extremes,
+        7 => utc_body,
+        2 => offset_body,
     ]
 }
 

--- a/tests/time_feature_surface.rs
+++ b/tests/time_feature_surface.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "time")]
+#![forbid(unsafe_code)]
+
+use connections::extended::Extended;
+use connections::time::{ODTMSECS, SDURU064};
+use std::time::Duration as StdDuration;
+use time::{Duration, OffsetDateTime};
+
+#[test]
+fn time_feature_enables_time_conn_surface() {
+    let at = OffsetDateTime::UNIX_EPOCH + Duration::seconds(1);
+    assert_eq!(ODTMSECS.ceil(Extended::Finite(at)), 1);
+
+    let ttl = StdDuration::from_secs(1);
+    assert_eq!(SDURU064.ceil(Extended::Finite(ttl)), Extended::Finite(1));
+}


### PR DESCRIPTION
Bump min bounds on time and uhlc. Enables jig usage.


On why `Cargo.toml:48` can move to `time >=0.3.47, <0.4`, and why the old upper-bound comment was no longer true:

The old generator built arbitrary `(Date, Time, UtcOffset)` values, including values near `Date::MIN / Date::MAX`. With newer time, comparisons/order normalization can shift those through UTC and hit the stricter year-range assertion. The current code no longer does that. `src/prop/arb.rs:784` now generates `OffsetDateTime` from unix nanoseconds inside a safe `UTCinstant` range, with a two-day margin at both ends, and only then applies offsets.
