### PR TITLE
fix: Represent uhlc ID puncture as Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ hifi = ["dep:hifitime"]
 # Enable HLC bridge Conns under `connections::uhlc::*` backed by the
 # `uhlc` crate. Pulled with `default-features = false` to skip
 # `uhlc`'s default `["std", "serde"]` (which would drag in
-# `humantime`, `lazy_static`, `log`, `rand/std`) — the iso /
-# right-Galois Conns shipped here only need the bare types.
+# `humantime`, `lazy_static`, `log`, `rand/std`) — the iso Conns
+# shipped here only need the bare types.
 uhlc = ["dep:uhlc"]
 
 # Re-export the crate's internal codegen macros under

--- a/src/kani/uhlc.rs
+++ b/src/kani/uhlc.rs
@@ -1,11 +1,7 @@
-//! Kani harnesses for [`crate::uhlc::NDURU064`] (iso) and
-//! [`crate::uhlc::HLIDLX16`] (right-Galois). NDURU064 gets the
-//! standard iso battery; HLIDLX16 gets the R-only battery plus a
-//! totality proof (`lower_never_panics`) that exercises
-//! `kani::any::<[u8; 16]>()` with **no precondition** — CBMC bit-
-//! blasts over the full domain and verifies the function returns
-//! a value (the lex-min ID) on the all-zero puncture without
-//! `unreachable!()` or `panic!()` firing.
+//! Kani harnesses for [`crate::uhlc::NDURU064`] and
+//! [`crate::uhlc::HLIDLX16`], both iso Conns. HLIDLX16 proves the
+//! all-zero puncture is represented by `None`, while every non-zero
+//! byte string round-trips through `Some(ID)`.
 
 use crate::conn::{ConnL, ConnR};
 use crate::core::LX;
@@ -14,10 +10,8 @@ use crate::uhlc::{HLIDLX16, NDURU064};
 use core::num::NonZeroU128;
 use uhlc::{ID, NTP64};
 
-fn arb_id_symbolic() -> ID {
-    let n: u128 = kani::any();
-    kani::assume(n != 0);
-    ID::from(NonZeroU128::new(n).unwrap())
+fn arb_opt_id_symbolic() -> Option<ID> {
+    NonZeroU128::new(kani::any()).map(ID::from)
 }
 
 mod ndur_u064 {
@@ -54,38 +48,34 @@ mod hlid_lx16 {
     use super::*;
 
     #[kani::proof]
+    fn galois_l() {
+        let a = arb_opt_id_symbolic();
+        let bytes: [u8; 16] = kani::any();
+        assert!(conn_laws::galois_l(&HLIDLX16.conn_l(), a, LX(bytes)));
+    }
+
+    #[kani::proof]
     fn galois_r() {
-        let a = arb_id_symbolic();
+        let a = arb_opt_id_symbolic();
         let bytes: [u8; 16] = kani::any();
-        assert!(conn_laws::galois_r(&HLIDLX16, a, LX(bytes)));
+        assert!(conn_laws::galois_r(&HLIDLX16.conn_r(), a, LX(bytes)));
     }
 
     #[kani::proof]
-    fn closure_r() {
-        let a = arb_id_symbolic();
-        assert!(conn_laws::closure_r(&HLIDLX16, a));
+    fn iso_roundtrip_l() {
+        let a = arb_opt_id_symbolic();
+        assert!(conn_laws::iso_roundtrip_l(&HLIDLX16.conn_l(), a));
     }
 
     #[kani::proof]
-    fn kernel_r() {
+    fn roundtrip_ceil() {
         let bytes: [u8; 16] = kani::any();
-        assert!(conn_laws::kernel_r(&HLIDLX16, LX(bytes)));
+        assert!(conn_laws::roundtrip_ceil(&HLIDLX16.conn_l(), LX(bytes)));
     }
 
     #[kani::proof]
-    fn monotone_r() {
-        let b1: [u8; 16] = kani::any();
-        let b2: [u8; 16] = kani::any();
-        assert!(conn_laws::monotone_r(&HLIDLX16, LX(b1), LX(b2)));
-    }
-
-    /// **Totality.** No `kani::assume` precondition — the full
-    /// `[u8; 16]` domain, including the all-zero puncture, must
-    /// produce a value (the lex-min ID at the puncture) without
-    /// `unreachable!()` or `panic!()` firing.
-    #[kani::proof]
-    fn lower_never_panics() {
-        let bytes: [u8; 16] = kani::any();
-        let _ = crate::conn::lower(&HLIDLX16, LX(bytes));
+    fn floor_le_ceil() {
+        let a = arb_opt_id_symbolic();
+        assert!(conn_laws::floor_le_ceil(&HLIDLX16, a));
     }
 }

--- a/src/uhlc.rs
+++ b/src/uhlc.rs
@@ -6,16 +6,14 @@
 //! | Conn         | Endpoints           | Law        |
 //! |--------------|---------------------|------------|
 //! | `NDURU064`   | `NTP64` ↔ `u64`     | iso (full) |
-//! | `HLIDLX16`   | `ID` ↔ `LX<16>`     | R-only     |
+//! | `HLIDLX16`   | `Option<ID>` ↔ `LX<16>` | iso (full) |
 //!
 //! `HLIDLX16` bridges to the opaque-bytes [`LX<16>`](crate::core::LX)
 //! rather than `NonZero<u128>`: `ID`'s derived `Ord` is byte-lex
 //! (LSB-first under LE storage), which is *not* the integer order on
 //! the underlying `u128`. `LX<16>`'s lex-from-byte-0 `Ord` matches
-//! `ID`'s. The connection is right-Galois (not iso): `LX<16>` has the
-//! all-zero value that `ID` doesn't, and saturating that puncture to
-//! the lex-min valid `ID` breaks the L-law but preserves the R-law.
-//! See the [`id`] submodule for the derivation.
+//! `ID`'s. `None` represents the all-zero byte-string puncture that no
+//! `ID` can inhabit, making the connection a full iso.
 
 pub mod id;
 pub mod ntp64;

--- a/src/uhlc/id.rs
+++ b/src/uhlc/id.rs
@@ -1,76 +1,53 @@
-//! `Conn<ID, LX<16>, R>` — right-Galois only. `ID` is a 16-byte
-//! LE-stored token whose derived `Ord` is byte-lex from byte 0 of
-//! `to_le_bytes()` (i.e., **LSB-first** under LE storage);
-//! [`LX<16>`](crate::core::LX) is the identity byte-wrapper with the
-//! same derived `Ord`. `LX<16>` carries one value (`LX([0; 16])`)
-//! that no `ID` represents — `ID`'s construction enforces a non-zero
-//! `u128` invariant (`uhlc-rs/src/id.rs:127-129`).
-//!
-//! The connection is total-via-saturation: the puncture maps to the
-//! lex-min valid `ID` (the byte array `[0,…,0,1]`, equal to
-//! `NonZeroU128::new(1 << 120).unwrap()`). L-Galois fails at that
-//! boundary; R-Galois holds, so this is a `conn_r!` rather than an
-//! `iso!`. See the plan-2026-05-19-03 derivation for the worked
-//! corner case.
-//!
-//! **No panics on reachable inputs.** `ID::try_from(&[u8; 16])`
-//! errors only on the all-zero array, which the puncture branch
-//! avoids by routing to `LEX_MIN_ID_BYTES`; the `unreachable!()`
-//! arm is dead code at every reachable call site, and the Kani
-//! `lower_never_panics` harness in `src/kani/uhlc.rs` proves
-//! totality over the full `[u8; 16]` domain.
+//! `Option<ID> ↔ LX<16>` iso. `ID` is a 16-byte LE-stored token whose
+//! derived `Ord` is byte-lex from byte 0 of `to_le_bytes()` (i.e.,
+//! **LSB-first** under LE storage); [`LX<16>`](crate::core::LX) is the
+//! identity byte-wrapper with the same derived `Ord`. `ID`'s
+//! construction enforces a non-zero `u128` invariant
+//! (`uhlc-rs/src/id.rs:127-129`), so `None` represents the single
+//! all-zero puncture and `Some(ID)` represents every non-zero byte
+//! string.
 
 use uhlc::ID;
 
 use crate::core::LX;
 
-/// Lex-min valid `ID` under the byte-lex-from-byte-0 Ord — byte 15
-/// = 1, all other bytes 0. Numerically this is `1 << 120`, but
-/// under `ID`'s derived `Ord` it is the minimum.
-const LEX_MIN_ID_BYTES: [u8; 16] = {
-    let mut b = [0u8; 16];
-    b[15] = 1;
-    b
-};
-
-fn id_to_lx16(id: ID) -> LX<16> {
-    LX(id.to_le_bytes())
+fn opt_id_to_lx16(id: Option<ID>) -> LX<16> {
+    match id {
+        None => LX([0u8; 16]),
+        Some(id) => LX(id.to_le_bytes()),
+    }
 }
 
-fn lx16_to_id(lx: LX<16>) -> ID {
-    let bytes: &[u8; 16] = if lx.0 == [0u8; 16] {
-        &LEX_MIN_ID_BYTES
-    } else {
-        &lx.0
-    };
-    ID::try_from(bytes).unwrap_or_else(|_| unreachable!())
+fn lx16_to_opt_id(lx: LX<16>) -> Option<ID> {
+    ID::try_from(&lx.0).ok()
 }
 
-crate::conn_r! {
-    /// `Conn<ID, LX<16>, R>` — `ID`'s 16-byte representation with
-    /// saturating decode at the all-zero byte string.
+crate::iso! {
+    /// `Option<ID> ↔ LX<16>` — `None` is the all-zero puncture;
+    /// `Some(ID)` is the lossless non-zero byte representation.
     ///
-    /// - `floor(&HLIDLX16, id)` (lossless): `id` → its LE-bytes-as-`LX<16>`.
-    /// - `lower(&HLIDLX16, lx)` (saturating): valid bytes round-trip; the
-    ///   single all-zero `LX([0; 16])` value saturates *up* to the
-    ///   lex-min valid `ID`. R-Galois holds at this boundary;
-    ///   L-Galois does not — that's why this is a `conn_r!`, not
-    ///   an `iso!`.
-    pub HLIDLX16 : ID => LX<16> {
-        inner: lx16_to_id,
-        floor: id_to_lx16,
+    /// - `floor(&HLIDLX16, None)` and `ceil(&HLIDLX16, None)` both return
+    ///   `LX([0; 16])`.
+    /// - `lower(&HLIDLX16, LX([0; 16]))` and
+    ///   `upper(&HLIDLX16, LX([0; 16]))` both return `None`.
+    /// - Every non-zero byte string decodes to `Some(ID)` and round-trips
+    ///   exactly.
+    pub HLIDLX16 : Option<ID> => LX<16> {
+        forward: opt_id_to_lx16,
+        back:    lx16_to_opt_id,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::conn::{ConnL, ConnR};
     use crate::prop::conn as conn_laws;
     use core::num::NonZeroU128;
     use proptest::prelude::*;
 
-    // `ID` doesn't derive `Debug`, so proptest strategies can't
-    // yield `ID` directly. Generate non-zero `u128` and construct
+    // `ID` doesn't derive `Debug`, so proptest strategies can't yield
+    // `Option<ID>` directly. Generate `Option<NonZeroU128>` and construct
     // `ID` in the body.
 
     fn arb_lx16() -> impl Strategy<Value = LX<16>> {
@@ -81,82 +58,61 @@ mod tests {
         ]
     }
 
-    fn arb_nonpuncture_lx16() -> impl Strategy<Value = LX<16>> {
-        any::<[u8; 16]>()
-            .prop_filter("non-zero bytes", |b| *b != [0u8; 16])
-            .prop_map(LX)
-    }
-
-    fn arb_nz_u128() -> impl Strategy<Value = NonZeroU128> {
+    fn arb_opt_nz_u128() -> impl Strategy<Value = Option<NonZeroU128>> {
         prop_oneof![
-            Just(NonZeroU128::new(1).unwrap()),
-            Just(NonZeroU128::MAX),
-            any::<u128>().prop_filter_map("non-zero u128", NonZeroU128::new),
+            Just(None),
+            Just(Some(NonZeroU128::new(1).unwrap())),
+            Just(Some(NonZeroU128::MAX)),
+            any::<u128>().prop_map(NonZeroU128::new),
         ]
     }
 
     proptest! {
         #[test]
-        fn galois_r(a in arb_nz_u128(), b in arb_lx16()) {
-            let id = ID::from(a);
-            prop_assert!(conn_laws::galois_r(&HLIDLX16, id, b));
+        fn iso_roundtrip_l(a in arb_opt_nz_u128()) {
+            let id = a.map(ID::from);
+            prop_assert!(conn_laws::iso_roundtrip_l(&HLIDLX16.conn_l(), id));
         }
         #[test]
-        fn closure_r(a in arb_nz_u128()) {
-            let id = ID::from(a);
-            prop_assert!(conn_laws::closure_r(&HLIDLX16, id));
+        fn roundtrip_ceil(b in arb_lx16()) {
+            prop_assert!(conn_laws::roundtrip_ceil(&HLIDLX16.conn_l(), b));
         }
         #[test]
-        fn kernel_r(b in arb_lx16()) {
-            prop_assert!(conn_laws::kernel_r(&HLIDLX16, b));
+        fn galois_l(a in arb_opt_nz_u128(), b in arb_lx16()) {
+            let id = a.map(ID::from);
+            prop_assert!(conn_laws::galois_l(&HLIDLX16.conn_l(), id, b));
         }
         #[test]
-        fn monotone_r(b1 in arb_lx16(), b2 in arb_lx16()) {
-            prop_assert!(conn_laws::monotone_r(&HLIDLX16, b1, b2));
+        fn galois_r(a in arb_opt_nz_u128(), b in arb_lx16()) {
+            let id = a.map(ID::from);
+            prop_assert!(conn_laws::galois_r(&HLIDLX16.conn_r(), id, b));
         }
         #[test]
-        fn roundtrip_floor_nonpuncture(b in arb_nonpuncture_lx16()) {
-            // floor(lower(b)) == b on non-puncture inputs.
-            prop_assert_eq!(crate::conn::floor(&HLIDLX16, crate::conn::lower(&HLIDLX16, b)).0, b.0);
+        fn floor_le_ceil(a in arb_opt_nz_u128()) {
+            let id = a.map(ID::from);
+            prop_assert!(conn_laws::floor_le_ceil(&HLIDLX16, id));
+        }
+        #[test]
+        fn order_reflecting(b1 in arb_lx16(), b2 in arb_lx16()) {
+            prop_assert!(conn_laws::order_reflecting(&HLIDLX16, b1, b2));
         }
     }
 
-    /// The connection is R-only; this builds an ad-hoc L-Conn from
-    /// the same `(ceil, inner)` pair and asserts the L-Galois law
-    /// **fails** at the documented puncture corner. If a future
-    /// `ID`-Ord change silently makes the L-law hold, this test
-    /// will fail and force a revisit of the R-only choice.
     #[test]
-    fn l_law_fails_at_puncture() {
-        let l: crate::conn::Conn<ID, LX<16>> = crate::conn::Conn::new_l(id_to_lx16, lx16_to_id);
-        let a = ID::try_from(&LEX_MIN_ID_BYTES).unwrap();
-        let b = LX([0u8; 16]);
-        // ceil(a) = LX([0,...,0,1]) > LX([0;16]) (lex), so LHS false.
-        // inner(b) = a, so a ≤ inner(b) is true.
-        assert!(!conn_laws::galois_l(&l, a, b));
-    }
-
-    /// Totality at the puncture — the saturating decode lands on
-    /// the lex-min valid `ID`, no panic.
-    #[test]
-    fn lower_total_at_puncture() {
+    fn puncture_is_none() {
         let z = LX([0u8; 16]);
-        let id = crate::conn::lower(&HLIDLX16, z);
-        let mut expected = [0u8; 16];
-        expected[15] = 1;
-        assert_eq!(id.to_le_bytes(), expected);
+        assert!(crate::conn::lower(&HLIDLX16, z).is_none());
+        assert_eq!(crate::conn::floor(&HLIDLX16, None), z);
     }
 
-    /// Floor is lossless; round-trip via `lower(&HLIDLX16, ...)` returns the
-    /// original `ID` for every non-puncture byte string (which is
-    /// every byte string that came from a real `ID`).
     #[test]
-    fn floor_lower_roundtrip_spot() {
-        let id = ID::from(NonZeroU128::new(0x12345678).unwrap());
-        let lx = crate::conn::floor(&HLIDLX16, id);
-        assert_eq!(
-            crate::conn::lower(&HLIDLX16, lx).to_le_bytes(),
-            id.to_le_bytes()
-        );
+    fn nonzero_bytes_roundtrip_as_some_id() {
+        let mut bytes = [0u8; 16];
+        bytes[7] = 42;
+        let lx = LX(bytes);
+        let id = crate::conn::lower(&HLIDLX16, lx).unwrap();
+
+        assert_eq!(id.to_le_bytes(), bytes);
+        assert_eq!(crate::conn::floor(&HLIDLX16, Some(id)).0, bytes);
     }
 }


### PR DESCRIPTION
## Summary

This changes `HLIDLX16` from a saturating right-Galois connection over bare `ID` into a full iso over `Option<ID>`.

`None` now represents the all-zero `LX([0; 16])` puncture that `uhlc::ID` cannot inhabit, while every non-zero byte string decodes to `Some(ID)` and round-trips exactly.

## Root Cause

The previous repair saturated the all-zero byte string to the lex-min valid `ID`. That made the conversion total, but it did not represent the missing point and left `HLIDLX16` as an R-only connection. Adding `None` models the puncture directly.

## Impact

Callers using `HLIDLX16` now receive `Option<ID>` from `lower`/`upper`; `LX([0; 16])` maps to `None` instead of a synthetic `ID`.

## Verification

- `cargo fmt --check`
- `cargo test --features uhlc`
- `cargo clippy --features uhlc --all-targets -- -D warnings`
- `env RUSTDOCFLAGS="-D warnings" cargo doc --features uhlc --no-deps`